### PR TITLE
Sort node list by index

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
@@ -153,7 +153,10 @@ func _get_nodes_references(path: String) -> Dictionary:
 			var node_scene = load(path + "/" + node)
 			var instance = node_scene.instantiate()
 			if instance is SproutyDialogsBaseNode:
-				nodes_dict[node_name] = node_scene
+				nodes_dict[node_name] = {
+					"index": instance.node_list_index,
+					"scene": node_scene
+				}
 			instance.queue_free()
 	return nodes_dict
 
@@ -179,9 +182,9 @@ func _new_node(node_type: String, node_index: int, node_offset: Vector2, add_to_
 		printerr("[Sprouty Dialogs] Cannot load '" + node_type + "' node. "
 			+ "Go to Settings > General, check that the custom nodes are enabled "
 			+ "and that the '" + node_type + "' scene exist in the 'custom event nodes' folder.")
-		new_node = _nodes_references["placeholder_node"].instantiate()
+		new_node = _nodes_references["placeholder_node"]["scene"].instantiate()
 	else:
-		new_node = _nodes_references[node_type].instantiate()
+		new_node = _nodes_references[node_type]["scene"].instantiate()
 	
 	new_node.title = node_type.capitalize() + " #" + str(node_index)
 	new_node.name = node_type + "_" + str(node_index)
@@ -943,11 +946,14 @@ func on_node_option_selected(id: int) -> void:
 ## Set nodes list on popup node menu
 func _set_add_node_menu() -> void:
 	_add_node_menu.clear()
+	var sorted_nodes = _nodes_references.keys() as Array
+	sorted_nodes.sort_custom(func(a, b):
+		return _nodes_references[a]["index"] < _nodes_references[b]["index"])
 	var index = 0
-	for node in _nodes_references:
+	for node in sorted_nodes:
 		if node == "placeholder_node":
 			continue # Skip the placeholder node
-		var node_aux = _nodes_references[node].instantiate()
+		var node_aux = _nodes_references[node]["scene"].instantiate()
 		_add_node_menu.add_icon_item(node_aux.node_icon, node_aux.name.capitalize(), index)
 		_add_node_menu.set_item_metadata(index, node)
 		node_aux.queue_free()

--- a/addons/sprouty_dialogs/event_nodes/call_method_node.tscn
+++ b/addons/sprouty_dialogs/event_nodes/call_method_node.tscn
@@ -34,7 +34,7 @@ corner_detail = 5
 [node name="CallMethodNode" type="GraphNode" unique_id=386465807]
 custom_minimum_size = Vector2(200, 0)
 offset_right = 235.0
-offset_bottom = 208.0
+offset_bottom = 203.0
 theme = ExtResource("1_8pr20")
 theme_override_styles/titlebar = SubResource("StyleBoxFlat_34kpq")
 theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_8yx6b")
@@ -79,6 +79,7 @@ slot/3/draw_stylebox = true
 script = ExtResource("2_kwnl7")
 node_color = Color(0.6525743, 0.13914663, 0.99950343, 1)
 node_icon = ExtResource("3_xbrbu")
+node_list_index = 5
 
 [node name="GridContainer" type="GridContainer" parent="." unique_id=1517490971]
 layout_mode = 2

--- a/addons/sprouty_dialogs/event_nodes/comment_node.tscn
+++ b/addons/sprouty_dialogs/event_nodes/comment_node.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Texture2D" uid="uid://dutvcwiqufcor" path="res://addons/sprouty_dialogs/editor/icons/event_nodes/comment.svg" id="3_g6856"]
 [ext_resource type="Script" uid="uid://cybxpd2fvt5vq" path="res://addons/sprouty_dialogs/event_nodes/scripts/comment_node.gd" id="5_achcx"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_42b30"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_18nhy"]
 content_margin_left = 4.0
 content_margin_top = 4.0
 content_margin_right = 4.0
@@ -16,7 +16,7 @@ corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 5
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_cjfsv"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_lvxk1"]
 content_margin_left = 18.0
 content_margin_top = 12.0
 content_margin_right = 18.0
@@ -29,13 +29,13 @@ corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 5
 
-[node name="CommentNode" type="GraphNode"]
+[node name="CommentNode" type="GraphNode" unique_id=174925552]
 custom_minimum_size = Vector2(200, 0)
-offset_right = 9.0
-offset_bottom = 55.0
+offset_right = 200.0
+offset_bottom = 155.0
 theme = ExtResource("1_0q2mk")
-theme_override_styles/titlebar = SubResource("StyleBoxFlat_42b30")
-theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_cjfsv")
+theme_override_styles/titlebar = SubResource("StyleBoxFlat_18nhy")
+theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_lvxk1")
 resizable = true
 title = "Comment Node"
 slot/0/left_enabled = false
@@ -50,8 +50,9 @@ slot/0/draw_stylebox = true
 script = ExtResource("5_achcx")
 node_color = Color(0.154876, 0.154876, 0.154876, 1)
 node_icon = ExtResource("3_g6856")
+node_list_index = 8
 
-[node name="TextInput" type="TextEdit" parent="."]
+[node name="TextInput" type="TextEdit" parent="." unique_id=415333059]
 custom_minimum_size = Vector2(150, 100)
 layout_mode = 2
 size_flags_vertical = 3

--- a/addons/sprouty_dialogs/event_nodes/condition_node.tscn
+++ b/addons/sprouty_dialogs/event_nodes/condition_node.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="StyleBox" uid="uid://dfa36wxs72oc0" path="res://addons/sprouty_dialogs/editor/theme/empty_panel.tres" id="4_l3xvy"]
 [ext_resource type="Script" uid="uid://d1s7kmoh1qgr0" path="res://addons/sprouty_dialogs/event_nodes/scripts/condition_node.gd" id="5_swe6e"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_avnbs"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0tisq"]
 content_margin_left = 4.0
 content_margin_top = 4.0
 content_margin_right = 4.0
@@ -17,7 +17,7 @@ corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 5
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_que3n"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hgtp1"]
 content_margin_left = 18.0
 content_margin_top = 12.0
 content_margin_right = 18.0
@@ -30,12 +30,12 @@ corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 5
 
-[node name="ConditionNode" type="GraphNode"]
+[node name="ConditionNode" type="GraphNode" unique_id=279791330]
 offset_right = 429.0
 offset_bottom = 195.0
 theme = ExtResource("1_8k3p6")
-theme_override_styles/titlebar = SubResource("StyleBoxFlat_avnbs")
-theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_que3n")
+theme_override_styles/titlebar = SubResource("StyleBoxFlat_0tisq")
+theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_hgtp1")
 resizable = true
 title = "Condition Node"
 slot/0/left_enabled = true
@@ -68,25 +68,26 @@ slot/2/draw_stylebox = true
 script = ExtResource("5_swe6e")
 node_color = Color(1.66051e-06, 0.543819, 0.103967, 1)
 node_icon = ExtResource("3_7frl5")
+node_list_index = 3
 
-[node name="Container" type="HFlowContainer" parent="."]
+[node name="Container" type="HFlowContainer" parent="." unique_id=852834977]
 layout_mode = 2
 
-[node name="FirstVar" type="HBoxContainer" parent="Container"]
+[node name="FirstVar" type="HBoxContainer" parent="Container" unique_id=123342452]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TypeField" type="PanelContainer" parent="Container/FirstVar"]
+[node name="TypeField" type="PanelContainer" parent="Container/FirstVar" unique_id=1563625216]
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_styles/panel = ExtResource("4_l3xvy")
 
-[node name="ValueField" type="PanelContainer" parent="Container/FirstVar"]
+[node name="ValueField" type="PanelContainer" parent="Container/FirstVar" unique_id=1104308014]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_styles/panel = ExtResource("4_l3xvy")
 
-[node name="OperatorDropdown" type="OptionButton" parent="Container"]
+[node name="OperatorDropdown" type="OptionButton" parent="Container" unique_id=1622158335]
 custom_minimum_size = Vector2(48, 0)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -100,32 +101,32 @@ popup/item_1/id = 1
 popup/item_2/text = "<"
 popup/item_2/id = 2
 popup/item_3/text = ">"
-popup/item_3/id = 3
+popup/item_3/id = 4
 popup/item_4/text = "<="
-popup/item_4/id = 4
+popup/item_4/id = 3
 popup/item_5/text = ">="
 popup/item_5/id = 5
 
-[node name="SecondVar" type="HBoxContainer" parent="Container"]
+[node name="SecondVar" type="HBoxContainer" parent="Container" unique_id=156325431]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TypeField" type="PanelContainer" parent="Container/SecondVar"]
+[node name="TypeField" type="PanelContainer" parent="Container/SecondVar" unique_id=1771520238]
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_styles/panel = ExtResource("4_l3xvy")
 
-[node name="ValueField" type="PanelContainer" parent="Container/SecondVar"]
+[node name="ValueField" type="PanelContainer" parent="Container/SecondVar" unique_id=2021350787]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_styles/panel = ExtResource("4_l3xvy")
 
-[node name="True" type="Label" parent="."]
+[node name="True" type="Label" parent="." unique_id=1703958436]
 layout_mode = 2
 text = "True"
 horizontal_alignment = 2
 
-[node name="False" type="Label" parent="."]
+[node name="False" type="Label" parent="." unique_id=1893951328]
 layout_mode = 2
 text = "False"
 horizontal_alignment = 2

--- a/addons/sprouty_dialogs/event_nodes/dialogue_node.tscn
+++ b/addons/sprouty_dialogs/event_nodes/dialogue_node.tscn
@@ -8,7 +8,7 @@
 [ext_resource type="Script" uid="uid://bbxvuya7njed5" path="res://addons/sprouty_dialogs/event_nodes/scripts/dialogue_node.gd" id="5_v7cqa"]
 [ext_resource type="PackedScene" uid="uid://cpvp6sfoxqigr" path="res://addons/sprouty_dialogs/editor/components/expandable_text_box.tscn" id="6_2llfw"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5s4f0"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_lv0q5"]
 content_margin_left = 5.0
 content_margin_top = 5.0
 content_margin_right = 5.0
@@ -17,7 +17,7 @@ bg_color = Color(0.827451, 0.27451, 0.262745, 1)
 corner_radius_top_left = 5
 corner_radius_top_right = 5
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_358xh"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5s4f0"]
 content_margin_left = 5.0
 content_margin_top = 5.0
 content_margin_right = 5.0
@@ -35,8 +35,8 @@ offset_right = 250.0
 offset_bottom = 439.0
 size_flags_vertical = 3
 theme = ExtResource("1_05qy5")
-theme_override_styles/titlebar = SubResource("StyleBoxFlat_5s4f0")
-theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_358xh")
+theme_override_styles/titlebar = SubResource("StyleBoxFlat_lv0q5")
+theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_5s4f0")
 resizable = true
 title = "Dialogue Node"
 slot/0/left_enabled = true
@@ -87,6 +87,7 @@ slot/4/draw_stylebox = true
 script = ExtResource("5_v7cqa")
 node_color = Color(0.827451, 0.27451, 0.262745, 1)
 node_icon = ExtResource("4_hljjc")
+node_list_index = 1
 
 [node name="CharacterContainer" type="VBoxContainer" parent="." unique_id=1375918612]
 layout_mode = 2

--- a/addons/sprouty_dialogs/event_nodes/options_node.tscn
+++ b/addons/sprouty_dialogs/event_nodes/options_node.tscn
@@ -25,7 +25,7 @@ border_width_right = 2
 corner_radius_top_left = 5
 corner_radius_top_right = 5
 
-[sub_resource type="DPITexture" id="DPITexture_5rvxf"]
+[sub_resource type="DPITexture" id="DPITexture_vpchq"]
 _source = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\"><path fill=\"#ff5d5d\" d=\"M2 1v8.586l1.293-1.293a1 1 0 0 1 1.414 0L7 10.587l2.293-2.293a1 1 0 0 1 1.414 0L13 10.586l1-1V6H9V1H2zm8 0v4h4zm-6 9.414-2 2V15h12v-2.586l-.293.293a1 1 0 0 1-1.414 0L10 10.414l-2.293 2.293a1 1 0 0 1-1.414 0L4 10.414z\"/></svg>
 "
 
@@ -37,7 +37,7 @@ size_flags_vertical = 3
 theme = ExtResource("1_4odiy")
 theme_override_styles/titlebar = SubResource("StyleBoxFlat_qm86d")
 theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_6yiaj")
-position_offset = Vector2(0, 0.20000003)
+position_offset = Vector2(0, 0.23000005)
 resizable = true
 title = "Options Node"
 slot/0/left_enabled = true
@@ -61,10 +61,11 @@ slot/1/draw_stylebox = true
 script = ExtResource("5_jgvn8")
 node_color = Color(0.13186, 0.623383, 0.509555, 1)
 node_icon = ExtResource("3_d57bv")
+node_list_index = 2
 
 [node name="AddOptionButton" type="Button" parent="." unique_id=1720163507]
 layout_mode = 2
 text = "Add Option"
-icon = SubResource("DPITexture_5rvxf")
+icon = SubResource("DPITexture_vpchq")
 
 [connection signal="pressed" from="AddOptionButton" to="." method="_on_add_option_button_pressed"]

--- a/addons/sprouty_dialogs/event_nodes/scripts/base_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/base_node.gd
@@ -20,9 +20,10 @@ signal modified(modified: bool)
 
 ## Node color to display on the node titlebar.
 @export_color_no_alpha var node_color: Color
-
 ## Icon to display on the node titlebar.
 @export var node_icon: Texture2D
+## Node list position index
+@export var node_list_index: int = 0
 
 ## Name of the start node in the dialog tree where the node belongs.
 ## Used to find the start node in the graph editor on load.
@@ -95,7 +96,7 @@ func _set_node_titlebar():
 	remove_button.texture_normal = get_theme_icon('Remove', 'EditorIcons')
 	remove_button.stretch_mode = TextureButton.STRETCH_KEEP_ASPECT_CENTERED
 	if get_parent() is EditorSproutyDialogsGraphEditor:
-		remove_button.pressed.connect(get_parent().delete_node.bind(self))
+		remove_button.pressed.connect(get_parent().delete_node.bind(self ))
 	node_titlebar.add_child(remove_button)
 
 

--- a/addons/sprouty_dialogs/event_nodes/set_variable_node.tscn
+++ b/addons/sprouty_dialogs/event_nodes/set_variable_node.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://drlmb1kt08wlv" path="res://addons/sprouty_dialogs/editor/components/combo_box.tscn" id="5_oao84"]
 [ext_resource type="Texture2D" uid="uid://b4iocr6w7ajw2" path="res://addons/sprouty_dialogs/editor/icons/event_nodes/set-variable.svg" id="6_sx7hg"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0am0n"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7i5mu"]
 content_margin_left = 4.0
 content_margin_top = 4.0
 content_margin_right = 4.0
@@ -18,7 +18,7 @@ corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 5
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5130m"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_chfaq"]
 content_margin_left = 18.0
 content_margin_top = 12.0
 content_margin_right = 18.0
@@ -31,12 +31,12 @@ corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 5
 
-[node name="SetVariableNode" type="GraphNode"]
+[node name="SetVariableNode" type="GraphNode" unique_id=2134358531]
 offset_right = 537.0
 offset_bottom = 95.0
 theme = ExtResource("1_bouee")
-theme_override_styles/titlebar = SubResource("StyleBoxFlat_0am0n")
-theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_5130m")
+theme_override_styles/titlebar = SubResource("StyleBoxFlat_7i5mu")
+theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_chfaq")
 resizable = true
 title = "Set Variable Node"
 slot/0/left_enabled = true
@@ -51,24 +51,25 @@ slot/0/draw_stylebox = true
 script = ExtResource("5_5o0bh")
 node_color = Color(0.396078, 0.572549, 0, 1)
 node_icon = ExtResource("6_sx7hg")
+node_list_index = 4
 
-[node name="Container" type="HFlowContainer" parent="."]
+[node name="Container" type="HFlowContainer" parent="." unique_id=1557399764]
 layout_mode = 2
 
-[node name="VarField" type="HBoxContainer" parent="Container"]
+[node name="VarField" type="HBoxContainer" parent="Container" unique_id=622897151]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TypeField" type="PanelContainer" parent="Container/VarField"]
+[node name="TypeField" type="PanelContainer" parent="Container/VarField" unique_id=1425559046]
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_styles/panel = ExtResource("4_7k7se")
 
-[node name="NameInput" parent="Container/VarField" instance=ExtResource("5_oao84")]
+[node name="NameInput" parent="Container/VarField" unique_id=1323093229 instance=ExtResource("5_oao84")]
 layout_mode = 2
 placeholder_text = "Variable name..."
 
-[node name="OperatorDropdown" type="OptionButton" parent="Container"]
+[node name="OperatorDropdown" type="OptionButton" parent="Container" unique_id=98476796]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "The type of the value to set."
@@ -79,7 +80,7 @@ popup/item_0/id = 0
 popup/item_1/text = "+="
 popup/item_1/id = 1
 
-[node name="ValueField" type="PanelContainer" parent="Container"]
+[node name="ValueField" type="PanelContainer" parent="Container" unique_id=1789497864]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_styles/panel = ExtResource("4_7k7se")

--- a/addons/sprouty_dialogs/event_nodes/signal_node.tscn
+++ b/addons/sprouty_dialogs/event_nodes/signal_node.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Script" uid="uid://cyxxjwme4x1gg" path="res://addons/sprouty_dialogs/event_nodes/scripts/signal_node.gd" id="5_vbbrw"]
 [ext_resource type="Texture2D" uid="uid://xthom8qls1aa" path="res://addons/sprouty_dialogs/editor/icons/event_nodes/signal.svg" id="6_b1lau"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ee2or"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hndjr"]
 content_margin_left = 4.0
 content_margin_top = 4.0
 content_margin_right = 4.0
@@ -16,7 +16,7 @@ corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 5
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4kliv"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_mo55h"]
 content_margin_left = 18.0
 content_margin_top = 12.0
 content_margin_right = 18.0
@@ -29,12 +29,12 @@ corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 5
 
-[node name="SignalNode" type="GraphNode"]
+[node name="SignalNode" type="GraphNode" unique_id=1800147296]
 offset_right = 180.0
 offset_bottom = 114.0
 theme = ExtResource("1_j2rs0")
-theme_override_styles/titlebar = SubResource("StyleBoxFlat_ee2or")
-theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_4kliv")
+theme_override_styles/titlebar = SubResource("StyleBoxFlat_hndjr")
+theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_mo55h")
 resizable = true
 title = "Signal Node"
 slot/0/left_enabled = true
@@ -58,11 +58,12 @@ slot/1/draw_stylebox = true
 script = ExtResource("5_vbbrw")
 node_color = Color(0.52549, 0.282353, 1, 1)
 node_icon = ExtResource("6_b1lau")
+node_list_index = 6
 
-[node name="Label" type="Label" parent="."]
+[node name="Label" type="Label" parent="." unique_id=1205182436]
 layout_mode = 2
 text = "Argument"
 
-[node name="Input" type="LineEdit" parent="."]
+[node name="Input" type="LineEdit" parent="." unique_id=285390260]
 layout_mode = 2
 placeholder_text = "Value..."

--- a/addons/sprouty_dialogs/event_nodes/wait_node.tscn
+++ b/addons/sprouty_dialogs/event_nodes/wait_node.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Script" uid="uid://df36b060lsrjk" path="res://addons/sprouty_dialogs/event_nodes/scripts/wait_node.gd" id="5_w2kpx"]
 [ext_resource type="Texture2D" uid="uid://me1oaiuyigif" path="res://addons/sprouty_dialogs/editor/icons/event_nodes/wait.svg" id="6_hj7a4"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_kvgs0"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8t1qi"]
 content_margin_left = 4.0
 content_margin_top = 4.0
 content_margin_right = 4.0
@@ -16,7 +16,7 @@ corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 5
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_2pibj"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8fvvd"]
 content_margin_left = 18.0
 content_margin_top = 12.0
 content_margin_right = 18.0
@@ -29,12 +29,12 @@ corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 5
 
-[node name="WaitNode" type="GraphNode"]
-offset_right = 9.0
-offset_bottom = 55.0
+[node name="WaitNode" type="GraphNode" unique_id=118781460]
+offset_right = 145.0
+offset_bottom = 86.0
 theme = ExtResource("1_sdbh8")
-theme_override_styles/titlebar = SubResource("StyleBoxFlat_kvgs0")
-theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_2pibj")
+theme_override_styles/titlebar = SubResource("StyleBoxFlat_8t1qi")
+theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_8fvvd")
 title = "Wait Node"
 slot/0/left_enabled = true
 slot/0/left_type = 0
@@ -48,16 +48,17 @@ slot/0/draw_stylebox = true
 script = ExtResource("5_w2kpx")
 node_color = Color(0.0117647, 0.517647, 0.67451, 1)
 node_icon = ExtResource("6_hj7a4")
+node_list_index = 7
 
-[node name="Container" type="HBoxContainer" parent="."]
+[node name="Container" type="HBoxContainer" parent="." unique_id=1702291560]
 layout_mode = 2
 theme_override_constants/separation = 10
 
-[node name="Label" type="Label" parent="Container"]
+[node name="Label" type="Label" parent="Container" unique_id=1357544034]
 layout_mode = 2
 text = "Time"
 
-[node name="SpinBox" type="SpinBox" parent="Container"]
+[node name="SpinBox" type="SpinBox" parent="Container" unique_id=1594426017]
 layout_mode = 2
 step = 0.01
 allow_greater = true


### PR DESCRIPTION
The node list in the Graph Editor is now sorted by a given index for each node. This index is defined in the new `node_list_index` property of the `SproutyDialogsBaseNode` class.