### PR TITLE
Updated get_property_list and getter to have default return values

### DIFF
--- a/addons/sprouty_dialogs/nodes/dialog_player.gd
+++ b/addons/sprouty_dialogs/nodes/dialog_player.gd
@@ -168,7 +168,7 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 ## Set extra properties on editor
 func _get_property_list():
-	var props: Array[Dictionary] = [{}]
+	var props: Array[Dictionary] = []
 	if Engine.is_editor_hint():
 		props.append({
 			"name": &"_dialog_data",


### PR DESCRIPTION
In 4.7dev1, the addon doesn't load as dialog_player's get_property_list and getter function don't return values from all code paths; this PR fixes that. get_property_list returns an empty Array[Dictionary] object now, and the getter function returns null by default. Tested and functions just fine for me, but please review to see if there's anything I missed that this affects :)