### PR TITLE
Release Changes 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ Also, you have a [class reference](https://SproutyLabs.github.io/SproutyDialogsD
 
 These are some features that are planned to implement in the future:
 
+- [x] Text effect tags (e.g. to change the typing speed in between dialogues)
 - [x] Add more event nodes:
   - [x] Call method node
+  - [x] Jump to node
   - [ ] Character node
   - [ ] Randomize node
   - [ ] Play sound node
@@ -84,7 +86,6 @@ These are some features that are planned to implement in the future:
 - [ ] Grouping nodes support
 - [ ] Typing sounds support
 - [ ] A new class to handle the dialogue headlessly
-- [ ] Text effect tags (e.g. to change the typing speed in between dialogues)
 
 *And more to come!*
 

--- a/addons/sprouty_dialogs/plugin.cfg
+++ b/addons/sprouty_dialogs/plugin.cfg
@@ -3,5 +3,5 @@
 name="Sprouty Dialogs"
 description="A graph-based visual dialogue system for Godot"
 author="Sprouty Labs"
-version="1.1.2"
+version="1.2.0"
 script="plugin.gd"


### PR DESCRIPTION
## Release Changes 1.1.2 -> 1.2.0 (Minor)

- #39 
- #40 
- #42 
- #44 
- #46 
- #47 
- #48 
- #49 
- #50 
- #51 

### Why is time for a release?

We have a lot of changes here, many bugs fixes, improvements and some new features. So it's minor release time!

Now, we have support for custom text effect tags, thanks to the new framework introduced in #39. Also, a new node called "Jump To" node suggested in #37 was added in #48. This node allows to jump to another dialog tree by specifying its Start ID.

The options node now have conditions that allows options to be disabled or hidden, thanks to #40. Also, the wait node was updated in #49, you can now choose whether the dialog box will close while you wait or remain on the screen.