### PR TITLE
Add support to jump to another dialogue file in jump to node

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/dialogue_panel.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/dialogue_panel.gd
@@ -15,8 +15,8 @@ signal new_dialog_file_pressed
 ## Emitted when the open dialog file button is pressed
 signal open_dialog_file_pressed
 
-## Emitted when is requesting to open a character file
-signal open_character_file_request(path: String)
+## Emitted when is requesting to open a file
+signal open_file_request(path: String)
 ## Emitted when is requesting to play a dialog from a start node
 signal play_dialog_request(start_id: String)
 
@@ -77,7 +77,7 @@ func switch_current_graph(new_graph: EditorSproutyDialogsGraphEditor) -> void:
 	if not new_graph.is_connected("open_text_editor", _show_text_editor):
 		new_graph.open_text_editor.connect(_show_text_editor)
 		new_graph.update_text_editor.connect(_text_editor.update_text_editor)
-		new_graph.open_character_file_request.connect(open_character_file_request.emit)
+		new_graph.open_file_request.connect(open_file_request.emit)
 		new_graph.play_dialog_request.connect(play_dialog_request.emit)
 		new_graph.toolbar_expanded.connect(_on_toolbar_expanded)
 		new_graph.nodes_selection_changed.connect(_graph_toolbar.update_node_options)

--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
@@ -14,8 +14,8 @@ signal modified(modified: bool)
 ## Triggered when all the nodes are loaded
 signal nodes_loaded
 
-## Emitted when is requesting to open a character file
-signal open_character_file_request(path: String)
+## Emitted when is requesting to open a file
+signal open_file_request(path: String)
 ## Emitted when is requesting to play a dialog from a start node
 signal play_dialog_request(start_id: String)
 
@@ -218,11 +218,11 @@ func _connect_node_signals(node: SproutyDialogsBaseNode) -> void:
 			not is_connected("translation_enabled_changed", node.on_translation_enabled_changed):
 		translation_enabled_changed.connect(node.on_translation_enabled_changed)
 	
-	match node.node_type: # Connect specific node signals
-		"start_node":
-			node.play_dialog_request.connect(play_dialog_request.emit)
-		"dialogue_node":
-			node.open_character_file_request.connect(open_character_file_request.emit)
+	# Connect other signals
+	if node.has_signal("open_file_request"):
+		node.open_file_request.connect(open_file_request.emit)
+	if node.has_signal("play_dialog_request"):
+		node.play_dialog_request.connect(play_dialog_request.emit)
 
 
 ## Disconnect node signals
@@ -236,17 +236,17 @@ func _disconnect_node_signals(node: SproutyDialogsBaseNode) -> void:
 	if node.has_signal("update_text_editor"):
 		node.update_text_editor.disconnect(update_text_editor.emit)
 	
-	# Connect translation signals
+	# Disconnect translation signals
 	if node.has_signal("on_locales_changed"):
 		locales_changed.disconnect(node.on_locales_changed)
 	if node.has_signal("on_translation_enabled_changed"):
 		translation_enabled_changed.disconnect(node.on_translation_enabled_changed)
 	
-	match node.node_type: # Disconnect specific node signals
-		"start_node":
-			node.play_dialog_request.disconnect(play_dialog_request.emit)
-		"dialogue_node":
-			node.open_character_file_request.disconnect(open_character_file_request.emit)
+	# Disconnect other signals
+	if node.has_signal("open_file_request"):
+		node.open_file_request.disconnect(open_file_request.emit)
+	if node.has_signal("play_dialog_request"):
+		node.play_dialog_request.disconnect(play_dialog_request.emit)
 
 #endregion
 

--- a/addons/sprouty_dialogs/editor/scripts/editor.gd
+++ b/addons/sprouty_dialogs/editor/scripts/editor.gd
@@ -74,7 +74,7 @@ func _ready():
 	dialogue_panel.graph_editor_visible.connect(side_bar.csv_path_field_visible)
 	dialogue_panel.new_dialog_file_pressed.connect(file_manager.on_new_dialog_pressed)
 	dialogue_panel.open_dialog_file_pressed.connect(file_manager.on_open_file_pressed)
-	dialogue_panel.open_character_file_request.connect(file_manager.load_file)
+	dialogue_panel.open_file_request.connect(file_manager.load_file)
 	dialogue_panel.play_dialog_request.connect(play_dialog_scene)
 
 	# Character panel signals

--- a/addons/sprouty_dialogs/event_nodes/jump_to_node.tscn
+++ b/addons/sprouty_dialogs/event_nodes/jump_to_node.tscn
@@ -4,13 +4,14 @@
 [ext_resource type="Script" uid="uid://xa1ypu4ppqp6" path="res://addons/sprouty_dialogs/event_nodes/scripts/jump_to_node.gd" id="2_script"]
 [ext_resource type="Texture2D" uid="uid://da63a2wkyi8j6" path="res://addons/sprouty_dialogs/editor/icons/event_nodes/jump_to.svg" id="3_b1sp0"]
 [ext_resource type="PackedScene" uid="uid://drlmb1kt08wlv" path="res://addons/sprouty_dialogs/editor/components/combo_box.tscn" id="3_combo"]
+[ext_resource type="Texture2D" uid="uid://cdnxgodp2ep" path="res://addons/sprouty_dialogs/editor/icons/event_nodes/dialogue.svg" id="5_uqmym"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_b1sp0"]
 content_margin_left = 4.0
 content_margin_top = 4.0
 content_margin_right = 4.0
 content_margin_bottom = 4.0
-bg_color = Color(0.176471, 0.639216, 0.592157, 1)
+bg_color = Color(0, 0.5324174, 0.36580393, 1)
 corner_radius_top_left = 3
 corner_radius_top_right = 3
 corner_radius_bottom_right = 3
@@ -22,7 +23,7 @@ content_margin_left = 18.0
 content_margin_top = 12.0
 content_margin_right = 18.0
 content_margin_bottom = 12.0
-bg_color = Color(0.176471, 0.639216, 0.592157, 1)
+bg_color = Color(0, 0.5324174, 0.36580393, 1)
 border_color = Color(0.325, 0.325, 0.325, 0.6)
 corner_radius_top_left = 3
 corner_radius_top_right = 3
@@ -32,8 +33,8 @@ corner_detail = 5
 
 [node name="JumpToNode" type="GraphNode" unique_id=769019640]
 custom_minimum_size = Vector2(200, 0)
-offset_right = 240.0
-offset_bottom = 104.0
+offset_right = 229.0
+offset_bottom = 175.0
 theme = ExtResource("1_theme")
 theme_override_styles/titlebar = SubResource("StyleBoxFlat_b1sp0")
 theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_uqmym")
@@ -48,6 +49,24 @@ slot/0/right_type = 0
 slot/0/right_color = Color(1, 1, 1, 1)
 slot/0/right_icon = null
 slot/0/draw_stylebox = true
+slot/1/left_enabled = false
+slot/1/left_type = 0
+slot/1/left_color = Color(1, 1, 1, 1)
+slot/1/left_icon = null
+slot/1/right_enabled = false
+slot/1/right_type = 0
+slot/1/right_color = Color(1, 1, 1, 1)
+slot/1/right_icon = null
+slot/1/draw_stylebox = true
+slot/2/left_enabled = false
+slot/2/left_type = 0
+slot/2/left_color = Color(1, 1, 1, 1)
+slot/2/left_icon = null
+slot/2/right_enabled = false
+slot/2/right_type = 0
+slot/2/right_color = Color(1, 1, 1, 1)
+slot/2/right_icon = null
+slot/2/draw_stylebox = true
 script = ExtResource("2_script")
 node_color = Color(0, 0.5324174, 0.36580393, 1)
 node_icon = ExtResource("3_b1sp0")
@@ -65,5 +84,28 @@ text = "Start ID"
 unique_name_in_owner = true
 layout_mode = 2
 placeholder_text = "Start ID..."
+
+[node name="JumpToDialogueToggle" type="CheckButton" parent="." unique_id=923778960]
+layout_mode = 2
+tooltip_text = "Jump to a start ID of another dialogue file"
+text = "Jump to another file"
+
+[node name="DialogueContainer" type="VBoxContainer" parent="." unique_id=2016544915]
+layout_mode = 2
+
+[node name="HSeparator" type="HSeparator" parent="DialogueContainer" unique_id=1676983201]
+layout_mode = 2
+
+[node name="DialogueField" type="HBoxContainer" parent="DialogueContainer" unique_id=1154326112]
+layout_mode = 2
+
+[node name="DialogueButton" type="Button" parent="DialogueContainer/DialogueField" unique_id=842857424]
+unique_name_in_owner = true
+auto_translate_mode = 2
+layout_mode = 2
+size_flags_horizontal = 3
+disabled = true
+text = "(No one)"
+icon = ExtResource("5_uqmym")
 
 [editable path="Container/TargetIdInput"]

--- a/addons/sprouty_dialogs/event_nodes/jump_to_node.tscn
+++ b/addons/sprouty_dialogs/event_nodes/jump_to_node.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://drlmb1kt08wlv" path="res://addons/sprouty_dialogs/editor/components/combo_box.tscn" id="3_combo"]
 [ext_resource type="Texture2D" uid="uid://cdnxgodp2ep" path="res://addons/sprouty_dialogs/editor/icons/event_nodes/dialogue.svg" id="5_uqmym"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_b1sp0"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_uqmym"]
 content_margin_left = 4.0
 content_margin_top = 4.0
 content_margin_right = 4.0
@@ -18,7 +18,7 @@ corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 5
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_uqmym"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_m57uy"]
 content_margin_left = 18.0
 content_margin_top = 12.0
 content_margin_right = 18.0
@@ -34,10 +34,10 @@ corner_detail = 5
 [node name="JumpToNode" type="GraphNode" unique_id=769019640]
 custom_minimum_size = Vector2(200, 0)
 offset_right = 229.0
-offset_bottom = 175.0
+offset_bottom = 122.0
 theme = ExtResource("1_theme")
-theme_override_styles/titlebar = SubResource("StyleBoxFlat_b1sp0")
-theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_uqmym")
+theme_override_styles/titlebar = SubResource("StyleBoxFlat_uqmym")
+theme_override_styles/titlebar_selected = SubResource("StyleBoxFlat_m57uy")
 resizable = true
 title = "Jump To Node"
 slot/0/left_enabled = true
@@ -91,6 +91,7 @@ tooltip_text = "Jump to a start ID of another dialogue file"
 text = "Jump to another file"
 
 [node name="DialogueContainer" type="VBoxContainer" parent="." unique_id=2016544915]
+visible = false
 layout_mode = 2
 
 [node name="HSeparator" type="HSeparator" parent="DialogueContainer" unique_id=1676983201]

--- a/addons/sprouty_dialogs/event_nodes/scripts/dialogue_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/dialogue_node.gd
@@ -9,7 +9,7 @@ extends SproutyDialogsBaseNode
 # -----------------------------------------------------------------------------
 
 ## Emitted when is requesting to open a character file
-signal open_character_file_request(path: String)
+signal open_file_request(path: String)
 ## Emitted when press the expand button in a text box field
 signal open_text_editor(text_box: TextEdit)
 ## Emitted when a text box field gains focus and should update the text editor
@@ -145,8 +145,8 @@ func load_character(path: String) -> void:
 	# Show the character's display name and set the portrait dropdown
 	_character_button.disabled = false
 	_character_button.text = character.key_name.capitalize()
-	if not _character_button.pressed.is_connected(open_character_file_request.emit.bind(path)):
-		_character_button.pressed.connect(open_character_file_request.emit.bind(path))
+	if not _character_button.pressed.is_connected(open_file_request.emit.bind(path)):
+		_character_button.pressed.connect(open_file_request.emit.bind(path))
 	_set_portrait_dropdown(character)
 	_character_data = character
 

--- a/addons/sprouty_dialogs/event_nodes/scripts/jump_to_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/jump_to_node.gd
@@ -7,10 +7,24 @@ extends SproutyDialogsBaseNode
 ## Node to jump to another dialogue branch and return to the next output.
 # -----------------------------------------------------------------------------
 
+## Emitted when is requesting to open a dialogue file
+signal open_file_request(path: String)
+
 ## Start ID input field.
 @onready var _target_input: EditorSproutyDialogsComboBox = %TargetIdInput
 ## Start ID value.
 @onready var _target_id: String = _target_input.text
+## Jump to another dialogue file toggle
+@onready var _jump_to_dialogue_toggle: CheckButton = $JumpToDialogueToggle
+## Dialogue section container
+@onready var _dialogue_container: VBoxContainer = $DialogueContainer
+## Dialogue file button
+@onready var _dialogue_button: Button = %DialogueButton
+
+## Dialogue data resource
+var _dialogue_data: SproutyDialogsDialogueData
+## Dialogue resource picker
+var _dialogue_picker: EditorSproutyDialogsResourcePicker
 
 ## Empty field error style for input text.
 var _input_error_style := preload("res://addons/sprouty_dialogs/editor/theme/input_text_error.tres")
@@ -24,7 +38,7 @@ var _id_modified: bool = false
 
 
 func _ready():
-	super()
+	super ()
 	_target_input.input_changed.connect(_on_target_input_changed)
 	_target_input.input_focus_exited.connect(_on_target_input_focus_exited)
 	node_deselected.connect(_on_node_deselected)
@@ -33,6 +47,12 @@ func _ready():
 
 	if get_parent() and get_parent().has_signal("modified"):
 		get_parent().modified.connect(_on_graph_modified)
+	
+	_jump_to_dialogue_toggle.toggled.connect(_on_jump_to_dialogue_toggled)
+	_set_dialogue_picker()
+
+	_dialogue_container.hide()
+	_on_resized()
 
 
 #region === Node Data ==========================================================
@@ -44,6 +64,9 @@ func get_data() -> Dictionary:
 		"node_type": node_type,
 		"node_index": node_index,
 		"to_id": _target_id.to_upper(),
+		"jump_to_dialogue": _jump_to_dialogue_toggle.button_pressed,
+		"to_dialogue_uid": ResourceSaver.get_resource_id_for_path(
+				_dialogue_data.resource_path, true) if _dialogue_data else -1,
 		"to_node": get_output_connections(),
 		"to_dialog": to_dialog,
 		"offset": position_offset,
@@ -56,30 +79,52 @@ func set_data(dict: Dictionary) -> void:
 	node_type = dict["node_type"]
 	node_index = dict["node_index"]
 	to_node = dict["to_node"]
+	to_dialog = dict.get("to_dialog", "")
 	position_offset = dict["offset"]
 	size = dict["size"]
 
-	if dict.has("to_dialog"):
-		to_dialog = dict["to_dialog"]
-
 	_target_id = dict.get("to_id", "")
 	_target_input.set_value(_target_id)
-	_refresh_target_options()
+
+	if dict.has("to_dialogue_uid"):
+		var path = ""
+		if SproutyDialogsFileUtils.check_valid_uid_path(dict["to_dialogue_uid"]):
+			path = ResourceUID.get_id_path(dict["to_dialogue_uid"])
+			_load_dialogue(load(path))
+		elif path != "":
+			printerr("[Sprouty Dialogs] The dialogue file '" + path
+				+ "' cannot be found by Jump To Node #" + str(node_index)
+				+ ". Please check if the dialogue file exist or select another one.")
+	
+	_jump_to_dialogue_toggle.button_pressed = dict.get("jump_to_dialogue", false)
 
 #endregion
 
 
 ## Refresh the available target IDs from the graph editor.
 func _refresh_target_options() -> void:
-	if get_parent() and get_parent().has_method("get_start_ids"):
-		_target_input.set_options(get_parent().get_start_ids())
+	if _jump_to_dialogue_toggle.button_pressed:
+		if _dialogue_data:
+			_target_input.set_options(_dialogue_data.get_start_ids())
+		else:
+			_target_input.set_options([])
+	else:
+		if get_parent() and get_parent().has_method("get_start_ids"):
+			_target_input.set_options(get_parent().get_start_ids())
 
 
 ## Validate the target ID against the graph editor start IDs.
 func _is_valid_target_id(target_id: String) -> bool:
-	if target_id.is_empty() or not get_parent() or not get_parent().has_method("get_start_ids"):
+	if target_id.is_empty():
 		return false
-	for start_id in get_parent().get_start_ids():
+	
+	var from = get_parent()
+	if _jump_to_dialogue_toggle.button_pressed:
+		from = _dialogue_data # Get the start ids from selected dialogue file
+	
+	if not from or not from.has_method("get_start_ids"):
+		return false
+	for start_id in from.get_start_ids():
 		if str(start_id).to_upper() == target_id.to_upper():
 			return true
 	return false
@@ -93,10 +138,7 @@ func _on_graph_modified(_modified: bool) -> void:
 ## Update the target ID and become it uppercase.
 func _on_target_input_changed(new_text: String) -> void:
 	if _displaying_error:
-		_target_input.remove_theme_stylebox_override("normal")
-		get_parent().alerts.hide_alert(_target_error_alert)
-		_target_error_alert = null
-		_displaying_error = false
+		_hide_alerts()
 
 	var target_text = new_text.to_upper()
 	var caret_pos = _target_input.caret_column
@@ -139,6 +181,17 @@ func _on_target_input_focus_exited() -> void:
 		else:
 			get_parent().alerts.focus_alert(_target_error_alert)
 		_displaying_error = true
+	else:
+		_hide_alerts()
+
+
+# Hide the displayed alerts
+func _hide_alerts() -> void:
+	_target_input.remove_theme_stylebox_override("normal")
+	if _target_error_alert:
+		get_parent().alerts.hide_alert(_target_error_alert)
+	_target_error_alert = null
+	_displaying_error = false
 
 
 ## Active error alert when input is empty on node deselected.
@@ -150,3 +203,125 @@ func _on_node_deselected() -> void:
 func _on_tree_exiting() -> void:
 	if get_parent() and _target_error_alert:
 		get_parent().alerts.hide_alert(_target_error_alert)
+
+
+#region === Handle Dialogue Selection ==========================================
+
+## Load the dialogue data from the file field
+func _load_dialogue(dialogue: Resource) -> void:
+	if not dialogue:
+		_clear_dialogue_field()
+		return
+	
+	var path = dialogue.resource_path
+	if not dialogue is SproutyDialogsDialogueData:
+		printerr("[Sprouty Dialogs] Invalid dialogue resource: " + path)
+		_clear_dialogue_field()
+		return
+	
+	# Show the character's display name and set the portrait dropdown
+	_dialogue_button.disabled = false
+	_dialogue_button.text = path.get_file().get_basename().capitalize()
+	if not _dialogue_button.pressed.is_connected(open_file_request.emit.bind(path)):
+		_dialogue_button.pressed.connect(open_file_request.emit.bind(path))
+	_refresh_target_options()
+	_dialogue_data = dialogue
+
+
+## Set the dialogue resource picker
+func _set_dialogue_picker() -> void:
+	_dialogue_picker = EditorSproutyDialogsResourcePicker.new()
+	_dialogue_picker.resource_type = _dialogue_picker.ResourceType.DIALOGUE
+	_dialogue_picker.add_clear_button = true
+	_dialogue_button.get_parent().add_child(_dialogue_picker)
+	_dialogue_picker.resource_picked.connect(_on_dialogue_changed)
+	_dialogue_picker.clear_pressed.connect(_on_dialogue_clear)
+	_dialogue_button.disabled = true
+
+
+## Handle when the jump to dialogue button is toggled
+func _on_jump_to_dialogue_toggled(toggled_on: bool) -> void:
+	_dialogue_container.visible = toggled_on
+	_on_target_input_focus_exited()
+	_refresh_target_options()
+	_on_resized()
+	modified.emit(true)
+	
+	# --- UndoRedo ----------------------------------------------------------
+	undo_redo.create_action("Toggle Jump To Dialogue")
+	undo_redo.add_do_method(_jump_to_dialogue_toggle, "set_pressed_no_signal", toggled_on)
+	undo_redo.add_undo_method(_jump_to_dialogue_toggle, "set_pressed_no_signal", not toggled_on)
+	
+	undo_redo.add_do_property(_dialogue_container, "visible", toggled_on)
+	undo_redo.add_undo_property(_dialogue_container, "visible", not toggled_on)
+	undo_redo.add_do_method(self, "_refresh_target_options")
+	undo_redo.add_undo_method(self, "_refresh_target_options")
+	undo_redo.add_do_method(self, "_on_resized")
+	undo_redo.add_undo_method(self, "_on_resized")
+
+	undo_redo.add_do_method(self, "emit_signal", "modified", true)
+	undo_redo.add_undo_method(self, "emit_signal", "modified", false)
+	undo_redo.commit_action(false)
+	# -----------------------------------------------------------------------
+
+
+## Handle the dialogue file path changed signal
+func _on_dialogue_changed(res: Resource) -> void:
+	if not res:
+		return
+	var prev_dialogue = _dialogue_data
+	var prev_target_id = _target_id
+	_target_input.text = ""
+	_target_id = ""
+	_load_dialogue(res)
+	modified.emit(true)
+	
+	# --- UndoRedo ----------------------------------------------------------
+	undo_redo.create_action("Assign Dialogue")
+	undo_redo.add_do_method(self, "_load_dialogue", res)
+	undo_redo.add_undo_method(self, "_load_dialogue", prev_dialogue)
+
+	undo_redo.add_do_property(self, "_target_id", "")
+	undo_redo.add_do_property(_target_input, "text", "")
+	undo_redo.add_undo_property(self, "_target_id", prev_target_id)
+	undo_redo.add_undo_property(_target_input, "text", prev_target_id)
+
+	undo_redo.add_do_method(self, "emit_signal", "modified", true)
+	undo_redo.add_undo_method(self, "emit_signal", "modified", false)
+	undo_redo.commit_action(false)
+	# -----------------------------------------------------------------------
+
+
+# Handle when the dialogue is cleared
+func _on_dialogue_clear() -> void:
+	var prev_dialogue = _dialogue_data
+	var prev_target_id = _target_id
+	_target_input.text = ""
+	_target_id = ""
+	_clear_dialogue_field()
+	modified.emit(true)
+
+	# --- UndoRedo ----------------------------------------------------------
+	undo_redo.create_action("Clear Dialogue")
+	undo_redo.add_do_method(self, "_clear_dialogue_field")
+	undo_redo.add_undo_method(self, "_load_dialogue", prev_dialogue)
+
+	undo_redo.add_do_property(self, "_target_id", "")
+	undo_redo.add_do_property(_target_input, "text", "")
+	undo_redo.add_undo_property(self, "_target_id", prev_target_id)
+	undo_redo.add_undo_property(_target_input, "text", prev_target_id)
+
+	undo_redo.add_do_method(self, "emit_signal", "modified", true)
+	undo_redo.add_undo_method(self, "emit_signal", "modified", false)
+	undo_redo.commit_action(false)
+	# -----------------------------------------------------------------------
+
+
+## Clear the character field and reset the portrait dropdown
+func _clear_dialogue_field() -> void:
+	_dialogue_data = null
+	_refresh_target_options()
+	_dialogue_button.text = "(No one)"
+	_dialogue_button.disabled = true
+
+#endregion

--- a/addons/sprouty_dialogs/event_nodes/scripts/jump_to_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/jump_to_node.gd
@@ -67,6 +67,7 @@ func get_data() -> Dictionary:
 		"jump_to_dialogue": _jump_to_dialogue_toggle.button_pressed,
 		"to_dialogue_uid": ResourceSaver.get_resource_id_for_path(
 				_dialogue_data.resource_path, true) if _dialogue_data else -1,
+		"to_dialogue_path": _dialogue_data.resource_path if _dialogue_data else "",
 		"to_node": get_output_connections(),
 		"to_dialog": to_dialog,
 		"offset": position_offset,
@@ -87,12 +88,11 @@ func set_data(dict: Dictionary) -> void:
 	_target_input.set_value(_target_id)
 
 	if dict.has("to_dialogue_uid"):
-		var path = ""
 		if SproutyDialogsFileUtils.check_valid_uid_path(dict["to_dialogue_uid"]):
-			path = ResourceUID.get_id_path(dict["to_dialogue_uid"])
+			var path = ResourceUID.get_id_path(dict["to_dialogue_uid"])
 			_load_dialogue(load(path))
-		elif path != "":
-			printerr("[Sprouty Dialogs] The dialogue file '" + path
+		else:
+			printerr("[Sprouty Dialogs] The dialogue file '" + dict["to_dialogue_path"]
 				+ "' cannot be found by Jump To Node #" + str(node_index)
 				+ ". Please check if the dialogue file exist or select another one.")
 	
@@ -222,8 +222,8 @@ func _load_dialogue(dialogue: Resource) -> void:
 	# Show the character's display name and set the portrait dropdown
 	_dialogue_button.disabled = false
 	_dialogue_button.text = path.get_file().get_basename().capitalize()
-	if not _dialogue_button.pressed.is_connected(open_file_request.emit.bind(path)):
-		_dialogue_button.pressed.connect(open_file_request.emit.bind(path))
+	_dialogue_button.pressed.disconnect(open_file_request.emit.bind(path))
+	_dialogue_button.pressed.connect(open_file_request.emit.bind(path))
 	_refresh_target_options()
 	_dialogue_data = dialogue
 

--- a/addons/sprouty_dialogs/event_nodes/scripts/jump_to_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/jump_to_node.gd
@@ -91,7 +91,7 @@ func set_data(dict: Dictionary) -> void:
 		if SproutyDialogsFileUtils.check_valid_uid_path(dict["to_dialogue_uid"]):
 			var path = ResourceUID.get_id_path(dict["to_dialogue_uid"])
 			_load_dialogue(load(path))
-		else:
+		elif not dict["to_dialogue_path"].is_empty():
 			printerr("[Sprouty Dialogs] The dialogue file '" + dict["to_dialogue_path"]
 				+ "' cannot be found by Jump To Node #" + str(node_index)
 				+ ". Please check if the dialogue file exist or select another one.")
@@ -222,7 +222,8 @@ func _load_dialogue(dialogue: Resource) -> void:
 	# Show the character's display name and set the portrait dropdown
 	_dialogue_button.disabled = false
 	_dialogue_button.text = path.get_file().get_basename().capitalize()
-	_dialogue_button.pressed.disconnect(open_file_request.emit.bind(path))
+	if _dialogue_button.pressed.is_connected(open_file_request.emit.bind(path)):
+		_dialogue_button.pressed.disconnect(open_file_request.emit.bind(path))
 	_dialogue_button.pressed.connect(open_file_request.emit.bind(path))
 	_refresh_target_options()
 	_dialogue_data = dialogue

--- a/addons/sprouty_dialogs/nodes/dialog_player.gd
+++ b/addons/sprouty_dialogs/nodes/dialog_player.gd
@@ -39,7 +39,6 @@ signal dialog_player_stop()
 var _dialog_data: SproutyDialogsDialogueData:
 	set(value):
 		_dialog_data = value
-		_start_id = "(Select a dialog)"
 		if value:
 			_dialog_data_uid = ResourceLoader.get_resource_uid(value.resource_path)
 			_dialog_file_name = value.resource_path.get_file().get_basename()
@@ -49,6 +48,7 @@ var _dialog_data: SproutyDialogsDialogueData:
 			_dialog_file_name = ""
 			_starts_ids = []
 		if Engine.is_editor_hint():
+			_start_id = "(Select a dialog)"
 			notify_property_list_changed()
 			update_configuration_warnings()
 
@@ -568,6 +568,7 @@ func _process_node(node_name: String) -> void:
 			var jump_frame = _jump_stack.pop_back()
 			_start_id = jump_frame["start_id"]
 			_next_node_dialog = jump_frame["next_node_dialog"]
+			_dialog_data = jump_frame["dialog_data"]
 			var return_node = jump_frame["return_node"]
 			if return_node == "" or return_node == "END":
 				_process_node("END")
@@ -658,9 +659,13 @@ func _on_option_selected(option_index: int) -> void:
 
 
 ## Handle when a jump node is processed
-func _on_jump_to_node(start_node: String, start_id: String, return_node: String) -> void:
+func _on_jump_to_node(start_node: String, start_id: String,
+		return_node: String, dialog_data: SproutyDialogsDialogueData) -> void:
 	if not _is_running:
 		return
+	
+	var from_dialog_data = _dialog_data
+	_dialog_data = dialog_data
 
 	if start_node.is_empty():
 		start_node = _get_start_node_name(start_id)
@@ -673,6 +678,7 @@ func _on_jump_to_node(start_node: String, start_id: String, return_node: String)
 		"start_id": _start_id,
 		"next_node_dialog": _next_node_dialog,
 		"return_node": return_node,
+		"dialog_data": from_dialog_data,
 	})
 	_start_id = start_id
 	_next_node_dialog = ""

--- a/addons/sprouty_dialogs/utils/event_interpreter.gd
+++ b/addons/sprouty_dialogs/utils/event_interpreter.gd
@@ -28,7 +28,12 @@ signal options_processed(options: Array, next_nodes: Array, option_keys: Array, 
 ## Emitted when a signal node was processed.
 signal signal_processed(signal_id: String, args: Array, next_node: String)
 ## Emitted when a jump node was processed.
-signal jump_to_node(start_node: String, start_id: String, return_node: String)
+signal jump_to_node(
+	start_node: String,
+	start_id: String,
+	return_node: String,
+	dialog_data: SproutyDialogsDialogueData
+)
 
 ## Node processors reference dictionary.
 ## This dictionary maps the node type to its processing method.
@@ -230,7 +235,6 @@ func _process_jump_to(node_data: Dictionary) -> void:
 		if SproutyDialogsFileUtils.check_valid_uid_path(node_data.get("to_dialogue_uid", -1)):
 			var path = ResourceUID.get_id_path(node_data["to_dialogue_uid"])
 			dialog_data = load(path)
-			# TODO: Handle how to jump to another dialogue file
 		else:
 			push_warning("[Sprouty Dialogs] Jump To Node #" + str(node_data.node_index)
 			+ " cannot find the dialogue file '" + node_data["to_dialogue_path"] + "' to jump to.")
@@ -261,4 +265,4 @@ func _process_jump_to(node_data: Dictionary) -> void:
 		continue_to_node.emit(return_node)
 		return
 
-	jump_to_node.emit(start_node, target_id, return_node)
+	jump_to_node.emit(start_node, target_id, return_node, dialog_data)

--- a/addons/sprouty_dialogs/utils/event_interpreter.gd
+++ b/addons/sprouty_dialogs/utils/event_interpreter.gd
@@ -27,8 +27,6 @@ signal dialogue_processed(
 signal options_processed(options: Array, next_nodes: Array, option_keys: Array, disabled_flags: Array)
 ## Emitted when a signal node was processed.
 signal signal_processed(signal_id: String, args: Array, next_node: String)
-## Emitted when a wait node was processed
-signal wait_processed(wait_time: float, next_node: String)
 ## Emitted when a jump node was processed.
 signal jump_to_node(start_node: String, start_id: String, return_node: String)
 
@@ -226,6 +224,18 @@ func _process_jump_to(node_data: Dictionary) -> void:
 	if node_data.has("to_node") and node_data["to_node"].size() > 0:
 		return_node = node_data["to_node"][0]
 	var dialog_data: SproutyDialogsDialogueData = get_parent().get_dialog_data()
+
+	# Handle when jump to another dialogue file
+	if node_data.get("jump_to_dialogue", false):
+		if SproutyDialogsFileUtils.check_valid_uid_path(node_data.get("to_dialogue_uid", -1)):
+			var path = ResourceUID.get_id_path(node_data["to_dialogue_uid"])
+			dialog_data = load(path)
+			# TODO: Handle how to jump to another dialogue file
+		else:
+			push_warning("[Sprouty Dialogs] Jump To Node #" + str(node_data.node_index)
+			+ " cannot find the dialogue file '" + node_data["to_dialogue_path"] + "' to jump to.")
+			continue_to_node.emit(return_node)
+			return
 
 	if target_id.is_empty() or dialog_data == null:
 		push_warning("[Sprouty Dialogs] Jump To Node #" + str(node_data.node_index)


### PR DESCRIPTION
Add the support to jump to a dialog ID from another dialogue file in a Jump To Node.

<img width="456" height="244" alt="Captura de pantalla 2026-04-28 a la(s) 6 03 30 p m" src="https://github.com/user-attachments/assets/9315deb1-e630-42c6-8354-a21f900ab558" />

Now you can check *"jump to another file"*, select the file where is the dialog that you want to jump to, and enter its ID in the Start ID field to jump to it.

- Closes #59 