### PR TITLE
Fix character files saving

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_list_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_list_manager.gd
@@ -16,7 +16,7 @@ signal file_closed(metadata: Dictionary)
 ## Emitted when requesting to save a file.
 signal request_save_file(index: int)
 ## Emitted when requesting to save a file as.
-signal request_save_file_as()
+signal request_save_file_as(index: int)
 
 ## File search input
 @onready var _file_search: LineEdit = $FileSearch
@@ -43,6 +43,8 @@ var _closing_queue: Array[int] = []
 var _dialogs_count: int = 0
 ## Number of characters in the file list
 var _characters_count: int = 0
+## Item that was right clicked
+var _right_clicked_item: int = -1
 
 ## UndoRedo manager
 var undo_redo: EditorUndoRedoManager
@@ -317,7 +319,8 @@ func _on_empty_clicked(at_pos: Vector2, mouse_button_index: int) -> void:
 
 
 ## When a file is right clicked, show the file menu options
-func _on_item_clicked(_idx, at_pos: Vector2, mouse_button_index: int) -> void:
+func _on_item_clicked(index: int, at_pos: Vector2, mouse_button_index: int) -> void:
+	_right_clicked_item = index
 	_on_empty_clicked(at_pos, mouse_button_index)
 
 
@@ -327,11 +330,13 @@ func _on_file_menu_pressed(id: int) -> void:
 		0:
 			request_save_file.emit(get_current_index()) # Save current file
 		1:
-			request_save_file_as.emit() # Save file as
+			request_save_file_as.emit(_right_clicked_item) # Save file as
 		2:
 			close_file() # Close current file
 		3:
 			close_all() # Close all files
+	
+	_right_clicked_item = -1
 
 
 ## Set the confirm closing dialog actions

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -53,6 +53,9 @@ var _char_scene := preload("res://addons/sprouty_dialogs/editor/modules/characte
 ## Save shortcut (Command/Ctrl-S)
 var _save_shortcut: Shortcut = Shortcut.new()
 
+## File index to save as
+var _save_as_file_index: int = -1
+
 ## Editor main reference
 var plugin_editor: Control = null
 
@@ -74,14 +77,19 @@ func _ready() -> void:
 	_save_file_button.pressed.connect(save_file)
 
 	open_file_dialog.file_selected.connect(load_file)
-	save_file_dialog.file_selected.connect(save_file)
+	save_file_dialog.file_selected.connect(func(path): save_file(_save_as_file_index, path))
 	new_dialog_file_dialog.file_selected.connect(new_dialog_file)
 	new_char_file_dialog.file_selected.connect(new_character_file)
 
 	_file_list.file_selected.connect(switch_to_selected_file)
 	_file_list.file_closed.connect(_on_file_closed)
 	_file_list.request_save_file.connect(save_file)
-	_file_list.request_save_file_as.connect(save_file_dialog.popup_centered)
+	_file_list.request_save_file_as.connect((func(index):
+			_save_as_file_index=index
+			save_file_dialog.current_path=_file_list.get_item_metadata(index)["file_path"]
+			save_file_dialog.popup_centered()
+			)
+		)
 
 	_close_editor_warning.custom_action.connect(_on_confirm_closing_editor_action)
 	_close_editor_warning.canceled.connect(func(): return null)

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -321,6 +321,13 @@ func save_file(index: int = _file_list.get_current_index(), path: String = "") -
 		print("[Sprouty Dialogs] File '" + file_metadata.file_name + "' could not be saved.")
 		return
 	
+	# Update the character resources in the inspector
+	var inspector = Engine.get_singleton("EditorInterface").get_inspector()
+	var current_edited = inspector.get_edited_object()
+	if (current_edited is SproutyDialogsCharacterData and
+			current_edited.key_name == file_metadata["data"].key_name):
+		EditorInterface.edit_resource(file_metadata["data"])
+	
 	_file_list.set_item_metadata(index, file_metadata)
 	_file_list.set_file_as_modified(index, false)
 

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -315,7 +315,12 @@ func save_file(index: int = _file_list.get_current_index(), path: String = "") -
 			SproutyDialogsCSVFileManager.save_character_names_on_csv(data.key_name, data.display_name)
 	
 	# Save file on the given path
-	ResourceSaver.save(file_metadata["data"], save_path)
+	file_metadata["data"].take_over_path(save_path)
+	var result = ResourceSaver.save(file_metadata["data"], save_path, ResourceSaver.FLAG_REPLACE_SUBRESOURCE_PATHS)
+	if result != OK:
+		print("[Sprouty Dialogs] File '" + file_metadata.file_name + "' could not be saved.")
+		return
+	
 	_file_list.set_item_metadata(index, file_metadata)
 	_file_list.set_file_as_modified(index, false)
 


### PR DESCRIPTION
Fix a bug that prevents character files from saving properly when the character resource is open in the inspector, due to a cache issue.

Also, the "Save as..." option from popup menu in the file list was fixed, solving this error:

 `ERROR: core/object/object.cpp:1406 - Error calling from signal 'file_selected' to callable: 'VBoxContainer(file_manager.gd)::save_file': Cannot convert argument 1 from String to int.`


- Closes #61 