### PR TITLE
Release Changes 1.2.2

### DIFF
--- a/addons/sprouty_dialogs/plugin.cfg
+++ b/addons/sprouty_dialogs/plugin.cfg
@@ -3,5 +3,5 @@
 name="Sprouty Dialogs"
 description="A graph-based visual dialogue system for Godot"
 author="Sprouty Labs"
-version="1.2.1"
+version="1.2.2"
 script="plugin.gd"


### PR DESCRIPTION
## Release Changes 1.2.1 -> 1.2.2 (Patch)

- #58 
- #60 
- #62 

### Why is time for a release?

We have fixed a bug in #62, reported in #61, that prevented character files from being saved when the resource was open in the inspector at the same time, due to a cache error. Also, the "save as" option was fixed.

Furthermore, we have some new additions: In #58 a new special tag `[repeat]` was added, and now the Jump To Node can also jump to a start ID from another dialogue file (#60), suggested in #59. 

We needed to fix the character save bug as soon as possible, so it's patch time!