### PR TITLE
Fix character modification issue

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/file_manager/file_manager.tscn
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/file_manager.tscn
@@ -174,7 +174,7 @@ unique_name_in_owner = true
 oversampling_override = 1.0
 title = "Please Confirm..."
 initial_position = 4
-size = Vector2i(336, 106)
+size = Vector2i(399, 132)
 exclusive = false
 dialog_text = "There are modified dialogue/character resources.
 
@@ -197,6 +197,7 @@ filters = PackedStringArray("*.tres")
 
 [node name="OpenFile" type="FileDialog" parent="ContentContainer/Container/FileManager/PopupDialogs" unique_id=1262344259]
 auto_translate_mode = 1
+oversampling_override = 1.0
 title = "Open a File"
 initial_position = 4
 size = Vector2i(1500, 1000)
@@ -206,9 +207,23 @@ filters = PackedStringArray("*.tres")
 
 [node name="SaveFile" type="FileDialog" parent="ContentContainer/Container/FileManager/PopupDialogs" unique_id=296390590]
 auto_translate_mode = 1
+oversampling_override = 1.0
 initial_position = 4
 size = Vector2i(1500, 1000)
 filters = PackedStringArray("*.tres")
+
+[node name="MissingCharacters" type="ConfirmationDialog" parent="ContentContainer/Container/FileManager/PopupDialogs" unique_id=116836602]
+oversampling_override = 1.0
+title = "Missing character references"
+initial_position = 4
+size = Vector2i(699, 262)
+exclusive = false
+dialog_text = "There is some missing character references in the loaded dialogue.
+
+Missing characters:
+[list]
+
+Do you want to automatically search and reassing the missing characters?"
 
 [node name="BottomContainer" type="HBoxContainer" parent="ContentContainer/Container" unique_id=369707668]
 layout_mode = 2

--- a/addons/sprouty_dialogs/editor/modules/file_manager/file_manager.tscn
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/file_manager.tscn
@@ -214,16 +214,18 @@ filters = PackedStringArray("*.tres")
 
 [node name="MissingCharacters" type="ConfirmationDialog" parent="ContentContainer/Container/FileManager/PopupDialogs" unique_id=116836602]
 oversampling_override = 1.0
-title = "Missing character references"
+title = "Missing characters"
 initial_position = 4
 size = Vector2i(699, 262)
 exclusive = false
-dialog_text = "There is some missing character references in the loaded dialogue.
+dialog_text = "Some character references are missing from the loaded dialog file:
+[dialogue]
 
 Missing characters:
 [list]
 
-Do you want to automatically search and reassing the missing characters?"
+Do you want to automatically search and reassing the missing characters?
+(Otherwise, all missing references will be removed from the dialog file!)"
 
 [node name="BottomContainer" type="HBoxContainer" parent="ContentContainer/Container" unique_id=369707668]
 layout_mode = 2

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -345,19 +345,22 @@ func save_file(index: int = _file_list.get_current_index(), path: String = "") -
 
 ## Check for missing character references in a dialogue resource
 func _check_missing_characters(dialog_data: SproutyDialogsDialogueData) -> void:
+	var char_references = dialog_data.get_all_character_references()
 	var missing_chars = []
 	var char_list = ""
+
 	for id in dialog_data.characters.keys():
 		for char in dialog_data.characters[id].keys():
-			if dialog_data.characters[id][char] < 0:
+			if not SproutyDialogsFileUtils.check_valid_uid_path(dialog_data.characters[id][char]):
 				if not missing_chars.has(char):
 					missing_chars.append(char)
-					char_list += "\n - " + char.capitalize()
+					char_list += "\n - " + char.capitalize() + " (References: " + str(char_references[char]) + ")"
 	
 	if not missing_chars.is_empty():
 		if _missing_chars_dialog.confirmed.is_connected(_reassign_missing_characters.bind(dialog_data)):
 			_missing_chars_dialog.confirmed.disconnect(_reassign_missing_characters.bind(dialog_data))
 		_missing_chars_dialog.confirmed.connect(_reassign_missing_characters.bind(dialog_data))
+		_missing_chars_dialog.dialog_text = _missing_chars_dialog.dialog_text.replace("[dialogue]", dialog_data.resource_path)
 		_missing_chars_dialog.dialog_text = _missing_chars_dialog.dialog_text.replace("[list]", char_list)
 		_missing_chars_dialog.popup_centered()
 
@@ -376,7 +379,7 @@ func _reassign_missing_characters(dialog_data: SproutyDialogsDialogueData) -> vo
 	var chars_not_found = []
 	for id in dialog_data.characters.keys():
 		for char in dialog_data.characters[id].keys():
-			if dialog_data.characters[id][char] < 0:
+			if not SproutyDialogsFileUtils.check_valid_uid_path(dialog_data.characters[id][char]):
 				if characters.has(char):
 					dialog_data.characters[id][char] = characters[char]
 				else:

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -36,6 +36,8 @@ signal all_character_files_closed
 @onready var save_file_dialog: FileDialog = $PopupDialogs/SaveFile
 ## Close editor warning dialog
 @onready var _close_editor_warning: AcceptDialog = %CloseEditorWarning
+## Missing character references dialog
+@onready var _missing_chars_dialog: ConfirmationDialog = $PopupDialogs/MissingCharacters
 
 ## File list manager
 @onready var _file_list: Control = $FileList
@@ -236,7 +238,7 @@ func _new_character_from_resource(resource: SproutyDialogsCharacterData) -> Cont
 #region === Save and Load ======================================================
 
 ## Load data from a dialog or character resource file
-func load_file(path: String) -> void:
+func load_file(path: String, check_resources: bool = true) -> void:
 	if _file_list.is_file_loaded(path):
 		_file_list.switch_to_file_path(path)
 		return
@@ -255,6 +257,8 @@ func load_file(path: String) -> void:
 			_file_list.new_file_item(path, resource, graph, csv_path)
 			request_to_switch_tab.emit(0)
 			_save_file_button.disabled = false
+			if check_resources:
+				_check_missing_characters(resource)
 		
 		elif resource is SproutyDialogsCharacterData:
 			SproutyDialogsFileUtils.set_recent_file_path("character_files", path)
@@ -337,8 +341,65 @@ func save_file(index: int = _file_list.get_current_index(), path: String = "") -
 
 #endregion
 
-#region === File options buttons ===============================================
+#region === Check missing resources ============================================
 
+## Check for missing character references in a dialogue resource
+func _check_missing_characters(dialog_data: SproutyDialogsDialogueData) -> void:
+	var missing_chars = []
+	var char_list = ""
+	for id in dialog_data.characters.keys():
+		for char in dialog_data.characters[id].keys():
+			if dialog_data.characters[id][char] < 0:
+				if not missing_chars.has(char):
+					missing_chars.append(char)
+					char_list += "\n - " + char.capitalize()
+	
+	if not missing_chars.is_empty():
+		if _missing_chars_dialog.confirmed.is_connected(_reassign_missing_characters.bind(dialog_data)):
+			_missing_chars_dialog.confirmed.disconnect(_reassign_missing_characters.bind(dialog_data))
+		_missing_chars_dialog.confirmed.connect(_reassign_missing_characters.bind(dialog_data))
+		_missing_chars_dialog.dialog_text = _missing_chars_dialog.dialog_text.replace("[list]", char_list)
+		_missing_chars_dialog.popup_centered()
+
+
+## Search and reassign missing characters in a dialogue resource
+func _reassign_missing_characters(dialog_data: SproutyDialogsDialogueData) -> void:
+	# Get all character resources
+	var characters: Dictionary = {}
+	var character_resources = SproutyDialogsFileUtils.get_resources_of_type("character")
+
+	for res in character_resources:
+		var uid = ResourceSaver.get_resource_id_for_path(res.resource_path, true)
+		characters[res.key_name] = uid
+	
+	# Reassign missing characters
+	var chars_not_found = []
+	for id in dialog_data.characters.keys():
+		for char in dialog_data.characters[id].keys():
+			if dialog_data.characters[id][char] < 0:
+				if characters.has(char):
+					dialog_data.characters[id][char] = characters[char]
+				else:
+					chars_not_found.append(char)
+	
+	if not chars_not_found.is_empty():
+		push_warning("[Sprouty Dialogs] Some characters were not found in the project: " \
+				+ str(chars_not_found).replace("[", "").replace("]", "") \
+				+ ". Please check if the character files exist.")
+	
+	# Update the dialogue resource
+	var result = ResourceSaver.save(dialog_data, dialog_data.resource_path)
+	if result != OK:
+		print("[Sprouty Dialogs] File '" + dialog_data.file_name + "' could not be saved.")
+		return
+	
+	# Reload the dialogue
+	await _file_list.close_file(_file_list.get_current_index())
+	load_file(dialog_data.resource_path, false)
+
+#endregion
+
+#region === File options buttons ===============================================
 ## Open file dialog to select a file
 func on_open_file_pressed() -> void:
 	open_file_dialog.set_current_dir(SproutyDialogsFileUtils.get_recent_file_path("sprouty_files"))

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -315,8 +315,10 @@ func save_file(index: int = _file_list.get_current_index(), path: String = "") -
 			SproutyDialogsCSVFileManager.save_character_names_on_csv(data.key_name, data.display_name)
 	
 	# Save file on the given path
-	file_metadata["data"].take_over_path(save_path)
-	var result = ResourceSaver.save(file_metadata["data"], save_path, ResourceSaver.FLAG_REPLACE_SUBRESOURCE_PATHS)
+	if file_metadata["data"] is SproutyDialogsCharacterData:
+		file_metadata["data"].take_over_path(save_path)
+	
+	var result = ResourceSaver.save(file_metadata["data"], save_path)
 	if result != OK:
 		print("[Sprouty Dialogs] File '" + file_metadata.file_name + "' could not be saved.")
 		return
@@ -324,9 +326,9 @@ func save_file(index: int = _file_list.get_current_index(), path: String = "") -
 	# Update the character resources in the inspector
 	var inspector = Engine.get_singleton("EditorInterface").get_inspector()
 	var current_edited = inspector.get_edited_object()
-	if (current_edited is SproutyDialogsCharacterData and
-			current_edited.key_name == file_metadata["data"].key_name):
-		EditorInterface.edit_resource(file_metadata["data"])
+	if current_edited is SproutyDialogsCharacterData and file_metadata["data"] is SproutyDialogsCharacterData:
+		if current_edited.key_name == file_metadata["data"].key_name:
+			EditorInterface.edit_resource(file_metadata["data"])
 	
 	_file_list.set_item_metadata(index, file_metadata)
 	_file_list.set_file_as_modified(index, false)

--- a/addons/sprouty_dialogs/event_nodes/scripts/dialogue_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/dialogue_node.gd
@@ -136,7 +136,7 @@ func load_character(path: String) -> void:
 		_clear_character_field()
 		return
 	
-	var character = load(path)
+	var character = ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_IGNORE)
 	if not character is SproutyDialogsCharacterData:
 		printerr("[Sprouty Dialogs] Invalid character resource: " + path)
 		_clear_character_field()

--- a/addons/sprouty_dialogs/event_nodes/scripts/dialogue_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/dialogue_node.gd
@@ -145,8 +145,9 @@ func load_character(path: String) -> void:
 	# Show the character's display name and set the portrait dropdown
 	_character_button.disabled = false
 	_character_button.text = character.key_name.capitalize()
-	if not _character_button.pressed.is_connected(open_file_request.emit.bind(path)):
-		_character_button.pressed.connect(open_file_request.emit.bind(path))
+	if _character_button.pressed.is_connected(open_file_request.emit.bind(path)):
+		_character_button.pressed.disconnect(open_file_request.emit.bind(path))
+	_character_button.pressed.connect(open_file_request.emit.bind(path))
 	_set_portrait_dropdown(character)
 	_character_data = character
 

--- a/addons/sprouty_dialogs/resources/dialogue_data.gd
+++ b/addons/sprouty_dialogs/resources/dialogue_data.gd
@@ -89,3 +89,16 @@ func get_portraits_on_dialog(start_id: String) -> Dictionary:
 			else:
 				portraits[node["character"]].append(node["portrait"])
 	return portraits
+
+
+## Return all the character references count from the dialogue file
+func get_all_character_references() -> Dictionary:
+	var references = {}
+	for start_id in graph_data.keys():
+		for node in graph_data[start_id].values():
+			if node.has("character"):
+				if not references.has(node["character"]):
+					references[node["character"]] = 1
+				else:
+					references[node["character"]] += 1
+	return references

--- a/addons/sprouty_dialogs/utils/files/file_utils.gd
+++ b/addons/sprouty_dialogs/utils/files/file_utils.gd
@@ -130,3 +130,41 @@ static func create_new_scene_file(scene_path: String, scene_type: String) -> voi
 
 	# Set the recent file path
 	set_recent_file_path(scene_type.replace("_scene", "") + "_files", scene_path)
+
+
+## Return all the resources of a given type in the project.
+## The type can be: "dialogue" or "character" resource.
+static func get_resources_of_type(type: String = "dialogue", path: String = "res://") -> Array:
+	var dialogue_resources: Array = []
+	var dir = DirAccess.open(path)
+	
+	if not dir:
+		printerr("[Sprouty Dialogs] Cannot open directory: " + path)
+		return dialogue_resources
+	
+	dir.list_dir_begin()
+	var file_name = dir.get_next()
+	
+	while file_name != "":
+		# Skip hidden files and current/parent directory markers
+		if not file_name.begins_with("."):
+			var file_path = path.path_join(file_name)
+			
+			# If it's a directory, recurse
+			if dir.current_is_dir():
+				var sub_resources = get_resources_of_type(type, file_path)
+				dialogue_resources.append_array(sub_resources)
+			# If it's a file with .tres extension, try to load it
+			elif file_name.ends_with(".tres"):
+				var resource = load(file_path)
+				match type:
+					"dialogue":
+						if resource is SproutyDialogsDialogueData:
+							dialogue_resources.append(resource)
+					"character":
+						if resource is SproutyDialogsCharacterData:
+							dialogue_resources.append(resource)
+		
+		file_name = dir.get_next()
+	
+	return dialogue_resources


### PR DESCRIPTION
Fix bug introduced in #62 due to a cache issue. 

When a character resource is saved, the cache is reseted to update the resource in the inspector, but this breaks the character resources cached in dialogue resources that are open at the same time. 

This was fixed by ignoring cache references when loading a character resource into a dialogue node.

This error may have caused some dialogue files to lose their character references, so a check has been added that scans for missing references and automatically searches for character files in the project to reassign their references in the dialogue file when it is opened. 

<img width="823" height="495" alt="Captura de pantalla 2026-05-13 a la(s) 6 21 38 p m" src="https://github.com/user-attachments/assets/382cfc7d-18ce-49d9-bf4d-1cc3e52f5a51" />

If you encountered this error in a dialogue file and lost the characters, but then edited and saved the file without the character references, they cannot be recovered automatically. You will need to reassign them manually :(

But from now on, you'll be able to retrieve them automatically :D

- Closes #64 