### PR TITLE
Release Changes 1.2.3

### DIFF
--- a/addons/sprouty_dialogs/plugin.cfg
+++ b/addons/sprouty_dialogs/plugin.cfg
@@ -3,5 +3,5 @@
 name="Sprouty Dialogs"
 description="A graph-based visual dialogue system for Godot"
 author="Sprouty Labs"
-version="1.2.2"
+version="1.2.3"
 script="plugin.gd"


### PR DESCRIPTION
## Release Changes 1.2.2 -> 1.2.3 (Patch)

- #66

### Why is time for a release?

From the bug introduced in #62 we got a new patch in #66 making dialogue nodes ignore Godot's cache to avoid loosing chars references, featuring a recover prompt too. This should patch the issue for good!