### PR TITLE
Fix portrait entry when is inside a dialog box

### DIFF
--- a/addons/sprouty_dialogs/nodes/dialog_player.gd
+++ b/addons/sprouty_dialogs/nodes/dialog_player.gd
@@ -614,8 +614,12 @@ func _on_dialogue_processed(character_name: String, translated_name: String,
 		portrait: String, dialog_data: Dictionary, next_node: String) -> void:
 	_next_node = next_node
 	_update_dialog_box(character_name)
-	await _update_portrait(character_name, portrait)
-	_current_dialog_box.play_dialog(translated_name, dialog_data)
+	if get_character_data(character_name).portrait_on_dialog_box:
+		_current_dialog_box.play_dialog(translated_name, dialog_data)
+		await _update_portrait(character_name, portrait)
+	else:
+		await _update_portrait(character_name, portrait)
+		_current_dialog_box.play_dialog(translated_name, dialog_data)
 
 
 ## Handle when the options node is processed


### PR DESCRIPTION
The order in which a portrait appears when it is inside a dialog box has been corrected. Now the portrait appears after the dialog box opens.