### PR TITLE
Auto update portrait list in dialogue nodes when character change

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -19,6 +19,9 @@ signal all_dialog_files_closed
 ## Emitted when all character files have been closed
 signal all_character_files_closed
 
+## Emitted when a character has changed
+signal character_changed(character: SproutyDialogsCharacterData)
+
 ## New dialog button
 @onready var _new_dialog_button: Button = %NewDialogButton
 ## New character button
@@ -184,6 +187,7 @@ func new_dialog_file(path: String) -> void:
 ## Create a new graph instance and load the data from a resource
 func _new_graph_from_resource(resource: SproutyDialogsDialogueData) -> EditorSproutyDialogsGraphEditor:
 	var graph = _graph_scene.instantiate()
+	character_changed.connect(graph.character_changed.emit)
 	graph.modified.connect(_on_data_modified)
 	graph.undo_redo = undo_redo
 	add_child(graph)
@@ -310,6 +314,7 @@ func save_file(index: int = _file_list.get_current_index(), path: String = "") -
 	elif data is SproutyDialogsCharacterData:
 		data = file_metadata["cache_node"].get_character_data()
 		file_metadata["data"] = data
+		character_changed.emit(data)
 
 		# Save character names on csv file
 		if SproutyDialogsSettingsManager.get_setting("translate_character_names") \

--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
@@ -24,6 +24,9 @@ signal open_text_editor(text_box: TextEdit)
 ## Emitted when change the focus to another text box while the text editor is open
 signal update_text_editor(text_box: TextEdit)
 
+## Emitted when a character is changed
+signal character_changed(character: SproutyDialogsCharacterData)
+
 ## Emitted when the locales are changed
 signal locales_changed
 ## Emitted when the translation enabled state is changed
@@ -218,6 +221,11 @@ func _connect_node_signals(node: SproutyDialogsBaseNode) -> void:
 			not is_connected("translation_enabled_changed", node.on_translation_enabled_changed):
 		translation_enabled_changed.connect(node.on_translation_enabled_changed)
 	
+	# Connect character changed signal
+	if node.has_method("on_character_changed") and \
+			not is_connected("character_changed", node.on_character_changed):
+		character_changed.connect(node.on_character_changed)
+
 	# Connect other signals
 	if node.has_signal("open_file_request"):
 		node.open_file_request.connect(open_file_request.emit)

--- a/addons/sprouty_dialogs/event_nodes/scripts/dialogue_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/dialogue_node.gd
@@ -45,6 +45,8 @@ var _default_text_modified: bool = false
 
 ## Previous selected portrait index (for UndoRedo)
 var _previous_portrait_index: int = 0
+## Cache of the current portrait list to avoid unnecessary updates
+var _current_portrait_list: Array = []
 
 ## Collapse/Expand icons
 var _collapse_up_icon = preload("res://addons/sprouty_dialogs/editor/icons/interactable/collapse-up.svg")
@@ -159,7 +161,24 @@ func load_portrait(portrait: String) -> void:
 		return
 	
 	var portrait_index = _find_dropdown_item(_portrait_dropdown, portrait)
-	_portrait_dropdown.select(portrait_index)
+	if portrait_index == -1:
+		_portrait_dropdown.select(0) # Select "(No one)"
+	else:
+		_portrait_dropdown.select(portrait_index)
+
+
+## Update the portrait dropdown when the character's portrait list changes
+func on_character_changed(character: SproutyDialogsCharacterData) -> void:
+	if (character == null or _character_data == null) \
+			or (character.key_name != _character_data.key_name):
+		return # Different or null character, no need to update portraits
+	
+	if _get_portrait_list(character.portraits) == _current_portrait_list:
+		return # Portrait list hasn't changed, no need to update
+	
+	var previous_portrait = get_portrait()
+	_set_portrait_dropdown(character)
+	load_portrait(previous_portrait)
 
 
 ## Set the character resource picker
@@ -249,6 +268,9 @@ func _set_portrait_dropdown(character_data: SproutyDialogsCharacterData) -> void
 	var portrait_list = _get_portrait_list(portraits)
 	for portrait in portrait_list:
 		_portrait_dropdown.add_item(portrait)
+
+	_current_portrait_list = portrait_list
+	_current_portrait_list.erase("(No one)")
 
 
 ## Get the list of portrait paths from the portrait dictionary


### PR DESCRIPTION
Now, the list of portraits in the `Dialogue Node` updates automatically when the character changes on save, so you no longer need to reassign the character in the node to select a newly added portrait.