### PR TITLE
Auto update all variable fields when variables are saved

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/dialogue_panel.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/dialogue_panel.gd
@@ -25,6 +25,9 @@ signal translation_enabled_changed(enabled: bool)
 ## Emitted when the locales change
 signal locales_changed
 
+## Emitted when variables are saved
+signal variables_changed
+
 ## Start panel reference
 @onready var _start_panel: Panel = $StartPanel
 ## Graph editor container reference
@@ -51,6 +54,7 @@ func _ready() -> void:
 	_graph_toolbar.play_dialog_request.connect(play_dialog_request.emit)
 	_graph_toolbar.toolbar_collapsed.connect(_on_toolbar_collapsed)
 	_text_editor.text_editor_closed.connect(_on_text_editor_closed)
+	variables_changed.connect(_text_editor.update_variables)
 
 	_new_dialog_button.icon = get_theme_icon("Add", "EditorIcons")
 	_open_dialog_button.icon = get_theme_icon("Folder", "EditorIcons")
@@ -84,8 +88,9 @@ func switch_current_graph(new_graph: EditorSproutyDialogsGraphEditor) -> void:
 		new_graph.paste_selection_changed.connect(_graph_toolbar.update_paste_button)
 
 		_graph_toolbar.node_option_pressed.connect(new_graph.on_node_option_selected)
-		translation_enabled_changed.connect(new_graph.on_translation_enabled_changed)
-		locales_changed.connect(new_graph.on_locales_changed)
+		translation_enabled_changed.connect(new_graph.translation_enabled_changed.emit)
+		locales_changed.connect(new_graph.locales_changed.emit)
+		variables_changed.connect(new_graph.variables_changed.emit)
 	
 	new_graph.undo_redo = undo_redo
 	_graph_panel.add_child(new_graph)

--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
@@ -32,6 +32,9 @@ signal locales_changed
 ## Emitted when the translation enabled state is changed
 signal translation_enabled_changed(enabled: bool)
 
+## Emitted when variables are saved
+signal variables_changed
+
 ## Emitted when nodes are selected or deselected
 signal nodes_selection_changed(has_selection: bool)
 ## Emitted when the selection of nodes to paste change
@@ -114,16 +117,6 @@ func _input(_event):
 	if (not _add_node_menu.visible) and _request_port > -1:
 		_request_node = ""
 		_request_port = -1
-
-
-## Notify the nodes that the locales have changed
-func on_locales_changed():
-	locales_changed.emit()
-
-
-## Notify the nodes that the translation enabled state has changed
-func on_translation_enabled_changed(enabled: bool):
-	translation_enabled_changed.emit(enabled)
 
 
 ## Returns all the start ids in the graph
@@ -226,6 +219,11 @@ func _connect_node_signals(node: SproutyDialogsBaseNode) -> void:
 			not is_connected("character_changed", node.on_character_changed):
 		character_changed.connect(node.on_character_changed)
 
+	# Connect variables changed signal
+	if node.has_method("on_variables_changed") and \
+			not is_connected("variables_changed", node.on_variables_changed):
+		variables_changed.connect(node.on_variables_changed)
+	
 	# Connect other signals
 	if node.has_signal("open_file_request"):
 		node.open_file_request.connect(open_file_request.emit)
@@ -245,11 +243,15 @@ func _disconnect_node_signals(node: SproutyDialogsBaseNode) -> void:
 		node.update_text_editor.disconnect(update_text_editor.emit)
 	
 	# Disconnect translation signals
-	if node.has_signal("on_locales_changed"):
+	if node.has_method("on_locales_changed"):
 		locales_changed.disconnect(node.on_locales_changed)
-	if node.has_signal("on_translation_enabled_changed"):
+	if node.has_method("on_translation_enabled_changed"):
 		translation_enabled_changed.disconnect(node.on_translation_enabled_changed)
 	
+	# Disconnect variables changed signal
+	if node.has_method("on_variables_changed"):
+		variables_changed.disconnect(node.on_variables_changed)
+
 	# Disconnect other signals
 	if node.has_signal("open_file_request"):
 		node.open_file_request.disconnect(open_file_request.emit)

--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
@@ -26,14 +26,13 @@ signal update_text_editor(text_box: TextEdit)
 
 ## Emitted when a character is changed
 signal character_changed(character: SproutyDialogsCharacterData)
+## Emitted when variables are saved
+signal variables_changed
 
 ## Emitted when the locales are changed
 signal locales_changed
 ## Emitted when the translation enabled state is changed
 signal translation_enabled_changed(enabled: bool)
-
-## Emitted when variables are saved
-signal variables_changed
 
 ## Emitted when nodes are selected or deselected
 signal nodes_selection_changed(has_selection: bool)
@@ -248,6 +247,10 @@ func _disconnect_node_signals(node: SproutyDialogsBaseNode) -> void:
 	if node.has_method("on_translation_enabled_changed"):
 		translation_enabled_changed.disconnect(node.on_translation_enabled_changed)
 	
+	# Disconnect character changed signal
+	if node.has_method("on_character_changed"):
+		character_changed.disconnect(node.on_character_changed)
+
 	# Disconnect variables changed signal
 	if node.has_method("on_variables_changed"):
 		variables_changed.disconnect(node.on_variables_changed)

--- a/addons/sprouty_dialogs/editor/modules/text_editor/scripts/text_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/text_editor/scripts/text_editor.gd
@@ -114,6 +114,11 @@ func change_option_bar(bar_index: int) -> void:
 	_options_bars[bar_index].show()
 
 
+## Update the variable options in the text editor
+func update_variables() -> void:
+	_on_variable_type_selected(_variable_type_dropdown.selected)
+
+
 ## Close the text editor
 func _on_close_button_pressed() -> void:
 	text_editor_closed.emit()

--- a/addons/sprouty_dialogs/editor/modules/variables/scripts/variable_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/variables/scripts/variable_editor.gd
@@ -9,6 +9,8 @@ extends MarginContainer
 ## editor. It allows the user to add, remove, rename, filter and save variables.
 # -----------------------------------------------------------------------------
 
+## Emitted when variables are saved
+signal variables_changed
 ## Emitted when a variable is changed
 signal variable_changed(var_data: Dictionary)
 ## Emitted when a text editor is called to edit a string variable
@@ -58,7 +60,7 @@ func _ready():
 	%AddVarButton.pressed.connect(_on_add_var_button_pressed)
 	%AddGroupButton.pressed.connect(_on_add_group_button_pressed)
 	%SearchBar.text_changed.connect(_on_search_bar_text_changed)
-	_save_button.pressed.connect(_on_save_button_pressed)
+	_save_button.pressed.connect(_save_variables)
 
 	%AddVarButton.icon = get_theme_icon("Add", "EditorIcons")
 	%AddGroupButton.icon = get_theme_icon("Folder", "EditorIcons")
@@ -75,14 +77,14 @@ func _ready():
 		_empty_label.show() # Show the empty label if there are no variables
 	
 	await get_tree().process_frame # Wait a frame to ensure settings are loaded
-	_load_variables_data(SproutyDialogsSettingsManager.get_setting("variables"))
+	_load_variables(SproutyDialogsSettingsManager.get_setting("variables"))
 
 
 func _input(event: InputEvent) -> void:
 	# Capture save shortcut (Command/Ctrl-S)
 	if _save_shortcut.matches_event(event) and event.is_pressed() and not event.is_echo():
 		if plugin_editor.visible and plugin_editor.tab_container.current_tab == 2:
-			_on_save_button_pressed() # Save variables
+			_save_variables()
 			get_viewport().set_input_as_handled()
 
 
@@ -107,8 +109,24 @@ func _get_variables_data(variables_array: Array = _variable_container.get_childr
 	return variables_data
 
 
+## Save the current variables to the project settings
+func _save_variables() -> void:
+	# Unmark all items as modified
+	for child in _variable_container.get_children():
+		if child is EditorSproutyDialogsVariableItem or \
+			child is EditorSproutyDialogsVariableGroup:
+			child.clear_modified_state()
+	_modified_counter = 0
+	_save_button.text = ""
+
+	# Save the variables to project settings
+	var data = _get_variables_data()
+	SproutyDialogsSettingsManager.set_setting("variables", data)
+	variables_changed.emit() # Emit signal to notify changes
+
+
 ## Load variables data into the editor
-func _load_variables_data(data: Dictionary, parent: Node = _variable_container) -> void:
+func _load_variables(data: Dictionary, parent: Node = _variable_container) -> void:
 	# Sort keys by their index value
 	var sorted_keys := data.keys()
 	sorted_keys.sort_custom(func(a, b):
@@ -132,7 +150,7 @@ func _load_variables_data(data: Dictionary, parent: Node = _variable_container) 
 			new_item.ready.connect(func():
 				new_item.set_item_name(name)
 				new_item.set_color(value.color)
-				_load_variables_data(value.variables, new_item) # Recursively load group variables
+				_load_variables(value.variables, new_item) # Recursively load group variables
 			)
 		
 		if parent is EditorSproutyDialogsVariableGroup:
@@ -310,21 +328,6 @@ func _on_add_group_button_pressed() -> void:
 ## Handle variable changes
 func _on_variable_changed(var_data: Dictionary) -> void:
 	variable_changed.emit(var_data)
-
-
-## Save the current variables to the project settings
-func _on_save_button_pressed() -> void:
-	# Unmark all items as modified
-	for child in _variable_container.get_children():
-		if child is EditorSproutyDialogsVariableItem or \
-			child is EditorSproutyDialogsVariableGroup:
-			child.clear_modified_state()
-	_modified_counter = 0
-	_save_button.text = ""
-
-	# Save the variables to project settings
-	var data = _get_variables_data()
-	SproutyDialogsSettingsManager.set_setting("variables", data)
 
 
 ## Handle the removal of a variable item

--- a/addons/sprouty_dialogs/editor/modules/variables/scripts/variable_panel.gd
+++ b/addons/sprouty_dialogs/editor/modules/variables/scripts/variable_panel.gd
@@ -8,6 +8,9 @@ extends Container
 ## variables in the Sprouty Dialogs editor.
 # -----------------------------------------------------------------------------
 
+## Emitted when variables are saved
+signal variables_changed
+
 ## Variable editor
 @onready var _variable_editor: EditorSproutyDialogsVariableEditor = $VariableEditor
 ## Text editor for edit string variables
@@ -28,6 +31,9 @@ var undo_redo: EditorUndoRedoManager:
 
 func _ready():
 	# Connect signals
+	_variable_editor.variables_changed.connect(variables_changed.emit)
+	variables_changed.connect(_text_editor.update_variables)
+	
 	_variable_editor.open_text_editor.connect(_on_open_text_editor)
 	_variable_editor.update_text_editor.connect(_text_editor.update_text_editor)
 	_text_editor.hide()

--- a/addons/sprouty_dialogs/editor/scripts/editor.gd
+++ b/addons/sprouty_dialogs/editor/scripts/editor.gd
@@ -77,6 +77,8 @@ func _ready():
 	dialogue_panel.open_file_request.connect(file_manager.load_file)
 	dialogue_panel.play_dialog_request.connect(play_dialog_scene)
 
+	variable_panel.variables_changed.connect(dialogue_panel.variables_changed.emit)
+
 	# Character panel signals
 	character_panel.new_character_file_pressed.connect(
 			file_manager.on_new_character_pressed)

--- a/addons/sprouty_dialogs/event_nodes/scripts/condition_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/condition_node.gd
@@ -44,19 +44,6 @@ func _ready():
 		operator_dropdown.add_item(operator, operators[operator])
 
 
-## Set the type dropdowns and connect their signals
-func _set_type_dropdown(dropdown_field: Node, field_index: int) -> void:
-	var types_dropdown = SproutyDialogsVariableUtils.get_types_dropdown(
-			true, ["Nil", "Dictionary", "Array"] # Excluded from options
-		)
-	dropdown_field.add_child(types_dropdown)
-	_type_dropdowns[field_index] = dropdown_field.get_node("TypeDropdown")
-	_type_dropdowns[field_index].item_selected.connect(_on_type_selected.bind(field_index))
-
-	_type_dropdowns[field_index].select(0) # Default type (Variable)
-	_set_value_field(0, field_index) # Default type (Variable)
-
-
 #region === Node Data ==========================================================
 
 func get_data() -> Dictionary:
@@ -122,6 +109,27 @@ func load_type_data(data: Dictionary, field_index: int) -> void:
 	_type_indexes[field_index] = type_index
 
 #endregion
+
+
+## Handle when the variables have changed to update the variable dropdown options
+func on_variables_changed() -> void:
+	for i in range(2):
+		var type = _type_dropdowns[i].get_item_id(_type_dropdowns[i].selected)
+		if type == 40: # If type is Variable, update the options
+			_value_inputs[i].set_options(SproutyDialogsVariableUtils.get_variables_of_type())
+
+
+## Set the type dropdowns and connect their signals
+func _set_type_dropdown(dropdown_field: Node, field_index: int) -> void:
+	var types_dropdown = SproutyDialogsVariableUtils.get_types_dropdown(
+			true, ["Nil", "Dictionary", "Array"] # Excluded from options
+		)
+	dropdown_field.add_child(types_dropdown)
+	_type_dropdowns[field_index] = dropdown_field.get_node("TypeDropdown")
+	_type_dropdowns[field_index].item_selected.connect(_on_type_selected.bind(field_index))
+
+	_type_dropdowns[field_index].select(0) # Default type (Variable)
+	_set_value_field(0, field_index) # Default type (Variable)
 
 
 ## Set a value field based on the variable type

--- a/addons/sprouty_dialogs/event_nodes/scripts/set_variable_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/set_variable_node.gd
@@ -109,6 +109,14 @@ func set_data(dict: Dictionary) -> void:
 #endregion
 
 
+## Handle when the variables have changed to update the variable dropdown options
+func on_variables_changed() -> void:
+	# Update the variable dropdown options based on the current type
+	var type = _type_dropdown.get_item_id(_type_dropdown.selected)
+	var metadata = _type_dropdown.get_item_metadata(_type_dropdown.selected)
+	_name_input.set_options(SproutyDialogsVariableUtils.get_variables_of_type(type, metadata))
+
+
 ## Handle when the type is selected from the dropdown
 func _set_variable_type(index: int) -> void:
 	var type = _type_dropdown.get_item_id(index)


### PR DESCRIPTION
Now, all variable fields in text editors and nodes are automatically updated with the correct list of variables when you save them.