### PR TITLE
Auto update start IDs from external dialogue file in jump to node

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -19,6 +19,8 @@ signal all_dialog_files_closed
 ## Emitted when all character files have been closed
 signal all_character_files_closed
 
+## Emitted when a dialogue has changed
+signal dialogue_changed(dialogue: SproutyDialogsDialogueData)
 ## Emitted when a character has changed
 signal character_changed(character: SproutyDialogsCharacterData)
 
@@ -187,6 +189,7 @@ func new_dialog_file(path: String) -> void:
 ## Create a new graph instance and load the data from a resource
 func _new_graph_from_resource(resource: SproutyDialogsDialogueData) -> EditorSproutyDialogsGraphEditor:
 	var graph = _graph_scene.instantiate()
+	dialogue_changed.connect(graph.dialogue_changed.emit)
 	character_changed.connect(graph.character_changed.emit)
 	graph.modified.connect(_on_data_modified)
 	graph.undo_redo = undo_redo
@@ -293,6 +296,7 @@ func save_file(index: int = _file_list.get_current_index(), path: String = "") -
 		data.graph_data = graph_editor_data["nodes_data"]
 		data.dialogs = graph_editor_data["dialogs"]
 		data.characters = graph_editor_data["characters"]
+		dialogue_changed.emit(data)
 
 		# Set the CSV file path if exists
 		if SproutyDialogsFileUtils.check_valid_extension(_csv_file_field.get_value(), ["*.csv"]) \

--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
@@ -24,6 +24,8 @@ signal open_text_editor(text_box: TextEdit)
 ## Emitted when change the focus to another text box while the text editor is open
 signal update_text_editor(text_box: TextEdit)
 
+## Emitted when a dialogue has changed
+signal dialogue_changed(dialogue: SproutyDialogsDialogueData)
 ## Emitted when a character is changed
 signal character_changed(character: SproutyDialogsCharacterData)
 ## Emitted when variables are saved
@@ -213,6 +215,11 @@ func _connect_node_signals(node: SproutyDialogsBaseNode) -> void:
 			not is_connected("translation_enabled_changed", node.on_translation_enabled_changed):
 		translation_enabled_changed.connect(node.on_translation_enabled_changed)
 	
+	# Connect dialogue changed signal
+	if node.has_method("on_dialogue_changed") and \
+			not is_connected("dialogue_changed", node.on_dialogue_changed):
+		dialogue_changed.connect(node.on_dialogue_changed)
+
 	# Connect character changed signal
 	if node.has_method("on_character_changed") and \
 			not is_connected("character_changed", node.on_character_changed):
@@ -246,6 +253,10 @@ func _disconnect_node_signals(node: SproutyDialogsBaseNode) -> void:
 		locales_changed.disconnect(node.on_locales_changed)
 	if node.has_method("on_translation_enabled_changed"):
 		translation_enabled_changed.disconnect(node.on_translation_enabled_changed)
+	
+	# Disconnect dialogue changed signal
+	if node.has_method("on_dialogue_changed"):
+		dialogue_changed.disconnect(node.on_dialogue_changed)
 	
 	# Disconnect character changed signal
 	if node.has_method("on_character_changed"):

--- a/addons/sprouty_dialogs/event_nodes/scripts/jump_to_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/jump_to_node.gd
@@ -101,6 +101,19 @@ func set_data(dict: Dictionary) -> void:
 #endregion
 
 
+## Handle when the dialogue file is changed and update the target options.
+func on_dialogue_changed(dialogue: SproutyDialogsDialogueData) -> void:
+	if not _jump_to_dialogue_toggle.button_pressed:
+		return # Not jumping to another dialogue, no need to update start IDs
+
+	if (dialogue == null or _dialogue_data == null) \
+			or (dialogue.resource_path != _dialogue_data.resource_path):
+		return # Different or null dialogue, no need to update start IDs
+	
+	_dialogue_data = dialogue
+	_refresh_target_options()
+
+
 ## Refresh the available target IDs from the graph editor.
 func _refresh_target_options() -> void:
 	if _jump_to_dialogue_toggle.button_pressed:


### PR DESCRIPTION
Now, when you want to jump to another dialogue file, the list of start IDs in the Jump To Node updates automatically when the dialogue changes on save.