### PR TITLE
Release Changes 1.2.5

### DIFF
--- a/addons/sprouty_dialogs/plugin.cfg
+++ b/addons/sprouty_dialogs/plugin.cfg
@@ -3,5 +3,5 @@
 name="Sprouty Dialogs"
 description="A graph-based visual dialogue system for Godot"
 author="Sprouty Labs"
-version="1.2.4"
+version="1.2.5"
 script="plugin.gd"


### PR DESCRIPTION
## Release Changes 1.2.4 -> 1.2.5 (Patch)

- #88 

### Why is time for a release?

A recent null safety bug was accidentally released in last patch, we need to fix this quick. Thanks @Moumekie for the report in #87!