### PR TITLE
Fix connections from multiple options to the same node

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
@@ -452,10 +452,11 @@ func _load_nodes_connections() -> void:
 			if child.start_node_name != "":
 				child.start_node = get_node(child.start_node_name)
 			 # Connect each output node
-			for output_node in child.to_node:
+			for index in range(child.to_node.size()):
+				var output_node = child.to_node[index]
 				if output_node == "END":
 					continue
-				connect_node(child.name, child.to_node.find(output_node), output_node, 0)
+				connect_node(child.name, index, output_node, 0)
 				
 				var next_node = get_node_or_null(output_node)
 				if next_node != null:


### PR DESCRIPTION
When you connected multiple options from an Options Node to the same node, only the first connection was loaded when the file was loaded. This was because the input port was not specified correctly, which has been fixed.

- Closes #80 