### PR TITLE
Add setting to toggle saving only Sprouty resources on Ctrl+S/Cmd+S

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -135,7 +135,10 @@ func _input(event: InputEvent) -> void:
 		if plugin_editor.visible and plugin_editor.tab_container.current_tab < 2 \
 				and not _file_list.get_current_index() < 0:
 			save_file() # Save current file
-			get_viewport().set_input_as_handled()
+			
+			# Prevent default Ctrl-S behavior in the editor when saving only sprouty files
+			if SproutyDialogsSettingsManager.get_setting("save_sprouty_only"):
+				get_viewport().set_input_as_handled()
 
 
 func _notification(what: int) -> void:

--- a/addons/sprouty_dialogs/editor/modules/settings/general_settings.tscn
+++ b/addons/sprouty_dialogs/editor/modules/settings/general_settings.tscn
@@ -72,6 +72,28 @@ text = "dialogs_continue_action"
 placeholder_text = "Input action..."
 _placeholder_text = "Input action name..."
 
+[node name="SaveSproutyOnly" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=339926979]
+layout_mode = 2
+tooltip_text = "If enabled, pressing Ctrl-S/Cmd-S while the plugin editor is open will save only the Sprouty resources.
+The current scene and other open resources in Godot will not be saved.
+Otherwise, all open resources will be saved."
+
+[node name="Label" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/SaveSproutyOnly" unique_id=2091553416]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Save only Sprouty's resources on Ctrl-S/Cmd-S"
+
+[node name="ResetButton" type="Button" parent="MarginContainer/ScrollContainer/VBoxContainer/SaveSproutyOnly" unique_id=581636897]
+visible = false
+layout_mode = 2
+icon = ExtResource("3_og6kh")
+flat = true
+
+[node name="SaveSproutyOnlyToggle" type="CheckButton" parent="MarginContainer/ScrollContainer/VBoxContainer/SaveSproutyOnly" unique_id=1873526323]
+unique_name_in_owner = true
+layout_mode = 2
+button_pressed = true
+
 [node name="HSeparator" type="HSeparator" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=366730916]
 layout_mode = 2
 
@@ -147,6 +169,7 @@ flat = true
 [node name="DefaultPortraitSceneField" parent="MarginContainer/ScrollContainer/VBoxContainer/DefaultPortraitScene" unique_id=1154758004 instance=ExtResource("7_og6kh")]
 unique_name_in_owner = true
 layout_mode = 2
+scene_type = 1
 
 [node name="HSeparator2" type="HSeparator" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=1021078704]
 layout_mode = 2
@@ -240,6 +263,7 @@ size_flags_horizontal = 3
 text = "Use custom event nodes"
 
 [node name="ResetButton" type="Button" parent="MarginContainer/ScrollContainer/VBoxContainer/UseCustomNodes" unique_id=1328093936]
+visible = false
 layout_mode = 2
 icon = ExtResource("3_og6kh")
 flat = true
@@ -247,7 +271,6 @@ flat = true
 [node name="UseCustomNodesToggle" type="CheckButton" parent="MarginContainer/ScrollContainer/VBoxContainer/UseCustomNodes" unique_id=601995962]
 unique_name_in_owner = true
 layout_mode = 2
-button_pressed = true
 
 [node name="CustomNodesFolderWarning" type="RichTextLabel" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=1626517227]
 unique_name_in_owner = true

--- a/addons/sprouty_dialogs/editor/modules/settings/general_settings.tscn
+++ b/addons/sprouty_dialogs/editor/modules/settings/general_settings.tscn
@@ -74,14 +74,14 @@ _placeholder_text = "Input action name..."
 
 [node name="SaveSproutyOnly" type="HBoxContainer" parent="MarginContainer/ScrollContainer/VBoxContainer" unique_id=339926979]
 layout_mode = 2
-tooltip_text = "If enabled, pressing Ctrl-S/Cmd-S while the plugin editor is open will save only the Sprouty resources.
+tooltip_text = "If enabled, pressing Ctrl+S/Cmd+S while the plugin editor is open will save only the Sprouty resources.
 The current scene and other open resources in Godot will not be saved.
 Otherwise, all open resources will be saved."
 
 [node name="Label" type="Label" parent="MarginContainer/ScrollContainer/VBoxContainer/SaveSproutyOnly" unique_id=2091553416]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "Save only Sprouty's resources on Ctrl-S/Cmd-S"
+text = "Save only Sprouty's resources on Ctrl+S/Cmd+S"
 
 [node name="ResetButton" type="Button" parent="MarginContainer/ScrollContainer/VBoxContainer/SaveSproutyOnly" unique_id=581636897]
 visible = false

--- a/addons/sprouty_dialogs/editor/modules/settings/scripts/general_settings.gd
+++ b/addons/sprouty_dialogs/editor/modules/settings/scripts/general_settings.gd
@@ -10,6 +10,8 @@ extends HSplitContainer
 
 ## Continue input action field
 @onready var _continue_input_action_field: EditorSproutyDialogsComboBox = %ContinueInputActionField
+## Save sprouty only toggle
+@onready var _save_sprouty_only_toggle: CheckButton = %SaveSproutyOnlyToggle
 
 ## Default dialog box scene field
 @onready var _default_dialog_box_field: EditorSproutyDialogsSceneField = %DefaultDialogBoxField
@@ -42,6 +44,7 @@ func _ready():
 	_dialog_box_canvas_layer_field.value_changed.connect(_on_dialog_box_canvas_layer_changed)
 	_portrait_canvas_layer_field.value_changed.connect(_on_portrait_canvas_layer_changed)
 
+	_save_sprouty_only_toggle.toggled.connect(_on_save_sprouty_only_toggled)
 	_use_custom_nodes_toggle.toggled.connect(_on_use_custom_nodes_toggled)
 	_custom_nodes_folder_field.path_changed.connect(_on_custom_nodes_folder_path_changed)
 	_custom_interpreter_field.path_changed.connect(_on_custom_interpreter_path_changed)
@@ -95,6 +98,12 @@ func _load_settings() -> void:
 		SproutyDialogsSettingsManager.get_setting("continue_input_action")
 	)
 	_set_reset_button(_continue_input_action_field, "continue_input_action")
+
+	# Load the save sprouty only toggle
+	_save_sprouty_only_toggle.set_pressed(
+		SproutyDialogsSettingsManager.get_setting("save_sprouty_only")
+	)
+	_set_reset_button(_save_sprouty_only_toggle, "save_sprouty_only")
 
 	# Load the default dialog box
 	var default_dialog_box = SproutyDialogsSettingsManager.get_setting("default_dialog_box")
@@ -269,6 +278,11 @@ func _get_saved_setting(setting_name: String) -> Variant:
 func _on_continue_input_action_changed(new_value: String) -> void:
 	SproutyDialogsSettingsManager.set_setting("continue_input_action", new_value)
 	_show_reset_button(_continue_input_action_field, "continue_input_action")
+
+
+func _on_save_sprouty_only_toggled(toggled_on: bool) -> void:
+	SproutyDialogsSettingsManager.set_setting("save_sprouty_only", toggled_on)
+	_show_reset_button(_save_sprouty_only_toggle, "save_sprouty_only")
 
 
 ## Handle when the default dialog box path is changed

--- a/addons/sprouty_dialogs/editor/modules/variables/scripts/variable_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/variables/scripts/variable_editor.gd
@@ -85,7 +85,10 @@ func _input(event: InputEvent) -> void:
 	if _save_shortcut.matches_event(event) and event.is_pressed() and not event.is_echo():
 		if plugin_editor.visible and plugin_editor.tab_container.current_tab == 2:
 			_save_variables()
-			get_viewport().set_input_as_handled()
+
+			# Prevent default Ctrl-S behavior in the editor when saving only sprouty files
+			if SproutyDialogsSettingsManager.get_setting("save_sprouty_only"):
+				get_viewport().set_input_as_handled()
 
 
 ## Get the variables data from the container

--- a/addons/sprouty_dialogs/utils/settings_manager.gd
+++ b/addons/sprouty_dialogs/utils/settings_manager.gd
@@ -156,11 +156,18 @@ static var _settings_paths: Dictionary = {
 ## Returns a setting value from the plugin settings.
 ## If the setting is not found, it returns null and prints an error message.
 static func get_setting(setting_name: String) -> Variant:
-	if has_setting(setting_name):
+	if (ProjectSettings.has_setting(_settings_paths[setting_name]["path"]) \
+			and _settings_paths.has(setting_name)) or setting_name == "testing_locale":
 		return ProjectSettings.get_setting(_settings_paths[setting_name]["path"])
 	else:
-		printerr("[Sprouty Dialogs] Setting '" + setting_name + "' not found.")
-		return null
+		# Reset to default value if setting is missing, to register it in the project settings
+		if _settings_paths.has(setting_name):
+			reset_setting(setting_name)
+			return get_default_setting(setting_name) # Return default value
+		else:
+			# Setting not found in the settings paths
+			printerr("[Sprouty Dialogs] Setting '" + setting_name + "' not found.")
+			return null
 
 
 ## Sets a setting value in the plugin settings.

--- a/addons/sprouty_dialogs/utils/settings_manager.gd
+++ b/addons/sprouty_dialogs/utils/settings_manager.gd
@@ -22,6 +22,10 @@ static var _settings_paths: Dictionary = {
 		"path": "graph_dialogs/general/input/continue_input_action",
 		"default": "dialogs_continue_action"
 	},
+	"save_sprouty_only": {
+		"path": "graph_dialogs/general/input/save_sprouty_only",
+		"default": true
+	},
 	# Default scenes
 	"default_dialog_box": {
 		"path": "graph_dialogs/general/defaults/default_dialog_box",


### PR DESCRIPTION
A new option has been added that lets you choose whether pressing Ctrl+S/Cmd+S in the plugin editor saves only Sprouty resources (if enabled) or saves all open resources (the current scene and other resources).

- Closes #82 