### PR TITLE
Allow dialogue and comment nodes vertical resizing

### DIFF
--- a/addons/sprouty_dialogs/event_nodes/dialogue_node.tscn
+++ b/addons/sprouty_dialogs/event_nodes/dialogue_node.tscn
@@ -145,6 +145,7 @@ layout_mode = 2
 
 [node name="DialogContainer" type="VBoxContainer" parent="." unique_id=1980537437]
 layout_mode = 2
+size_flags_vertical = 3
 
 [node name="DialogHeader" type="HBoxContainer" parent="DialogContainer" unique_id=608982801]
 layout_mode = 2

--- a/addons/sprouty_dialogs/event_nodes/scripts/comment_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/comment_node.gd
@@ -73,3 +73,8 @@ func _on_text_input_focus_exited() -> void:
 	if _comment_modified:
 		_comment_modified = false
 		modified.emit(true)
+		
+		
+## Allow this node type to be resized vertically
+func _on_resized() -> void:
+	return

--- a/addons/sprouty_dialogs/event_nodes/scripts/dialogue_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/dialogue_node.gd
@@ -415,5 +415,9 @@ func _on_default_focus_exited() -> void:
 	if _default_text_modified:
 		_default_text_modified = false
 		modified.emit(true)
-
+		
+		
+## Allow this node type to be resized vertically
+func _on_resized() -> void:
+	return
 #endregion


### PR DESCRIPTION
Dialogue and comment nodes might need to be resized to get a full overview of the text they hold in the graph panel, but their vertical size was clamped to 0 in their parent class so they couldn't be resized vertically. 

By overriding `SproutyDialogsBaseNode` `_on_resized` callback in `dialogue_node.gd` and `comment_node.gd`, this PR allows dialogue and comment nodes to be resized vertically if needed.

-  Closes #105 