### PR TITLE
Make comment node's text wrap at its boundaries

### DIFF
--- a/addons/sprouty_dialogs/event_nodes/comment_node.tscn
+++ b/addons/sprouty_dialogs/event_nodes/comment_node.tscn
@@ -57,3 +57,4 @@ custom_minimum_size = Vector2(150, 100)
 layout_mode = 2
 size_flags_vertical = 3
 placeholder_text = "Write a comment..."
+wrap_mode = 1


### PR DESCRIPTION
To mirror dialogue nodes' behavior, this PR makes comment node's text wrap at its boundaries by changing it's `TextEdit` `wrap_mode` from `LINE_WRAPPING_NONE` to `LINE_WRAPPING_BOUNDARY`. 