### PR TITLE
Round size and offset values in nodes to prevent changes when zooming

### DIFF
--- a/addons/sprouty_dialogs/event_nodes/custom_event_nodes/scripts/custom_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/custom_event_nodes/scripts/custom_node.gd
@@ -17,7 +17,7 @@ var _text_modified: bool = false
 
 
 func _ready():
-	super () # Required to initialize the node
+	super() # Required to initialize the node
 
 	# Connect text input signals
 	_text_input.text_changed.connect(_on_text_input_changed)
@@ -36,8 +36,8 @@ func get_data() -> Dictionary:
 		# Required node data
 		"node_type": node_type,
 		"node_index": node_index,
-		"offset": position_offset,
-		"size": size,
+		"offset": position_offset.round(),
+		"size": size.round(),
 		
 		# Get the node output connections
 		"to_node": get_output_connections(),

--- a/addons/sprouty_dialogs/event_nodes/scripts/call_method_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/call_method_node.gd
@@ -31,7 +31,7 @@ var _previous_params: Array = []
 
 
 func _ready():
-	super ()
+	super()
 	_autoloads_dropdown.mouse_entered.connect(_on_autoload_mouse_entered)
 	_autoloads_dropdown.item_selected.connect(_on_autoload_selected)
 	_method_combo_box.editing_toggled.connect(_on_method_editing_toggled)
@@ -59,8 +59,8 @@ func get_data() -> Dictionary:
 		"parameters": _parameters_field.get_array(),
 		"to_node": get_output_connections(),
 		"to_dialog": to_dialog,
-		"offset": position_offset,
-		"size": size
+		"offset": position_offset.round(),
+		"size": size.round()
 	}
 	return dict
 

--- a/addons/sprouty_dialogs/event_nodes/scripts/comment_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/comment_node.gd
@@ -17,7 +17,7 @@ var _comment_modified: bool = false
 
 
 func _ready():
-	super ()
+	super()
 	# Connect text input signals
 	_text_input.text_changed.connect(_on_text_input_changed)
 	_text_input.focus_exited.connect(_on_text_input_focus_exited)
@@ -32,8 +32,8 @@ func get_data() -> Dictionary:
 		"node_type": node_type,
 		"node_index": node_index,
 		"comment_text": _comment_text,
-		"offset": position_offset,
-		"size": size
+		"offset": position_offset.round(),
+		"size": size.round()
 	}
 	return dict
 

--- a/addons/sprouty_dialogs/event_nodes/scripts/condition_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/condition_node.gd
@@ -32,7 +32,7 @@ var _values_modified: Array[bool] = [false, false]
 
 
 func _ready():
-	super ()
+	super()
 	_set_type_dropdown($Container/FirstVar/TypeField, 0)
 	_set_type_dropdown($Container/SecondVar/TypeField, 1)
 	
@@ -65,8 +65,8 @@ func get_data() -> Dictionary:
 		"operator": operator_dropdown.get_item_id(operator_dropdown.selected),
 		"to_node": get_output_connections(),
 		"to_dialog": to_dialog,
-		"offset": position_offset,
-		"size": size
+		"offset": position_offset.round(),
+		"size": size.round()
 	}
 	return dict
 

--- a/addons/sprouty_dialogs/event_nodes/scripts/dialogue_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/dialogue_node.gd
@@ -54,7 +54,7 @@ var _collapse_down_icon = preload("res://addons/sprouty_dialogs/editor/icons/int
 
 
 func _ready():
-	super ()
+	super()
 	# Connect signals to open and update text editor
 	_translation_boxes.open_text_editor.connect(open_text_editor.emit)
 	_default_text_box.open_text_editor.connect(open_text_editor.emit)
@@ -89,8 +89,8 @@ func get_data() -> Dictionary:
 		"char_expand": _character_expand_button.button_pressed,
 		"to_node": get_output_connections(),
 		"to_dialog": to_dialog,
-		"offset": position_offset,
-		"size": size
+		"offset": position_offset.round(),
+		"size": size.round()
 	}
 	return dict
 

--- a/addons/sprouty_dialogs/event_nodes/scripts/jump_to_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/jump_to_node.gd
@@ -38,7 +38,7 @@ var _id_modified: bool = false
 
 
 func _ready():
-	super ()
+	super()
 	_target_input.input_changed.connect(_on_target_input_changed)
 	_target_input.input_focus_exited.connect(_on_target_input_focus_exited)
 	node_deselected.connect(_on_node_deselected)
@@ -70,8 +70,8 @@ func get_data() -> Dictionary:
 		"to_dialogue_path": _dialogue_data.resource_path if _dialogue_data else "",
 		"to_node": get_output_connections(),
 		"to_dialog": to_dialog,
-		"offset": position_offset,
-		"size": size
+		"offset": position_offset.round(),
+		"size": size.round()
 	}
 	return dict
 

--- a/addons/sprouty_dialogs/event_nodes/scripts/options_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/options_node.gd
@@ -24,7 +24,7 @@ var _options_conditions: Array = []
 
 
 func _ready():
-	super ()
+	super()
 	$AddOptionButton.icon = get_theme_icon("Add", "EditorIcons")
 	if not get_child(0) is EditorSproutyDialogsOptionContainer:
 		_first_option = _add_new_option() # Add the first option
@@ -46,8 +46,8 @@ func get_data() -> Dictionary:
 		"options_conditions": [],
 		"to_node": get_output_connections(),
 		"to_dialog": to_dialog,
-		"offset": position_offset,
-		"size": size
+		"offset": position_offset.round(),
+		"size": size.round()
 	}
 	var data = dict[name.to_snake_case()]
 	

--- a/addons/sprouty_dialogs/event_nodes/scripts/placeholder_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/placeholder_node.gd
@@ -16,9 +16,10 @@ func get_data() -> Dictionary:
 	var dict := {}
 
 	# Update the position and connections
-	_node_data["offset"] = position_offset
 	_node_data["to_node"] = get_output_connections()
 	_node_data["to_dialog"] = to_dialog
+	_node_data["offset"] = position_offset.round()
+	_node_data["size"] = size.round()
 
 	dict[name.to_snake_case()] = _node_data
 	return dict # Return the updated node data

--- a/addons/sprouty_dialogs/event_nodes/scripts/set_variable_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/set_variable_node.gd
@@ -38,7 +38,7 @@ var _value_modified: bool = false
 
 
 func _ready():
-	super ()
+	super()
 	_operator_dropdown.item_selected.connect(_on_operator_selected)
 	_name_input.input_changed.connect(_on_name_input_changed)
 	_name_input.focus_exited.connect(_on_name_input_focus_exited)
@@ -70,8 +70,8 @@ func get_data() -> Dictionary:
 		"new_value": _var_value,
 		"to_node": get_output_connections(),
 		"to_dialog": to_dialog,
-		"offset": position_offset,
-		"size": size
+		"offset": position_offset.round(),
+		"size": size.round()
 	}
 	return dict
 

--- a/addons/sprouty_dialogs/event_nodes/scripts/signal_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/signal_node.gd
@@ -27,7 +27,7 @@ var _previous_args: Array = []
 
 
 func _ready():
-	super ()
+	super()
 	# Connect signals
 	_identifier_input.text_changed.connect(_on_identifier_input_changed)
 	_identifier_input.focus_exited.connect(_on_identifier_input_focus_exited)
@@ -51,8 +51,8 @@ func get_data() -> Dictionary:
 		"extra_args": _args_array.get_array(),
 		"to_node": get_output_connections(),
 		"to_dialog": to_dialog,
-		"offset": position_offset,
-		"size": size
+		"offset": position_offset.round(),
+		"size": size.round()
 	}
 	return dict
 

--- a/addons/sprouty_dialogs/event_nodes/scripts/start_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/start_node.gd
@@ -29,7 +29,7 @@ var _id_modified: bool = false
 
 
 func _ready():
-	super ()
+	super()
 	# Connect signals
 	_id_input_text.text_changed.connect(_on_id_input_changed)
 	_id_input_text.focus_exited.connect(_on_id_input_focus_exited)
@@ -50,8 +50,8 @@ func get_data() -> Dictionary:
 		"start_id": _start_id.to_upper(),
 		"to_node": get_output_connections(),
 		"to_dialog": to_dialog,
-		"offset": position_offset,
-		"size": size
+		"offset": position_offset.round(),
+		"size": size.round()
 	}
 	return dict
 

--- a/addons/sprouty_dialogs/event_nodes/scripts/wait_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/wait_node.gd
@@ -19,7 +19,7 @@ var _time_modified: bool = false
 
 
 func _ready():
-	super ()
+	super()
 	_time_input.value_changed.connect(_on_time_value_changed)
 	_time_input.focus_exited.connect(_on_time_input_focus_exited)
 	_close_dialog_check.toggled.connect(_on_close_dialog_toggled)
@@ -37,8 +37,8 @@ func get_data() -> Dictionary:
 		"close_dialog": _close_dialog_check.button_pressed,
 		"to_node": get_output_connections(),
 		"to_dialog": to_dialog,
-		"offset": position_offset,
-		"size": size
+		"offset": position_offset.round(),
+		"size": size.round()
 	}
 	return dict
 


### PR DESCRIPTION
Round the size and offset values in nodes to avoid unnecessary changes in node data when zooming.

- Closes #111 