### PR TITLE
Fix crash when using multiple portraits of the same character

### DIFF
--- a/addons/sprouty_dialogs/nodes/dialog_player.gd
+++ b/addons/sprouty_dialogs/nodes/dialog_player.gd
@@ -532,8 +532,9 @@ func stop() -> void:
 		for portrait in _portraits_instances[char].values():
 			if portrait: # Remove the character node with the portraits
 				var portrait_parent = portrait.get_parent()
-				portrait_parent.get_parent().remove_child(portrait_parent)
-				portrait_parent.queue_free()
+				if portrait_parent and portrait_parent.get_parent():
+					portrait_parent.get_parent().remove_child(portrait_parent)
+					portrait_parent.queue_free()
 	
 	# Free all dialog boxes displayed
 	for dialog_box in _dialog_box_instances.values():


### PR DESCRIPTION
When multiple portraits of the same character were used in the same dialogue tree, the game crash because the `DialogPlayer` attempted to release the same portrait more than once. A null safety check was added to fix this. 

- Closes #112 