### PR TITLE
Restore opened Sprouty files at startup

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/characters/scripts/character_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/characters/scripts/character_editor.gd
@@ -12,6 +12,8 @@ extends HSplitContainer
 
 ## Triggered when something is modified
 signal modified(modified: bool)
+## Emitted when the character editor UI state changes
+signal view_state_changed(editor_state: Dictionary)
 
 ## Label with the key name of the character
 @onready var _key_name_label: Label = %KeyNameLabel
@@ -114,6 +116,7 @@ func _ready() -> void:
 
 	_portrait_tree.show_portrait_editor_panel.connect(_show_portrait_editor_panel)
 	_portrait_tree.portrait_item_selected.connect(_on_portrait_selected)
+	_portrait_tree.portrait_tree_state_changed.connect(_on_portrait_tree_state_changed)
 	_portrait_tree.modified.connect(_on_modified)
 	_portrait_tree.undo_redo = undo_redo
 
@@ -152,8 +155,8 @@ func _on_description_text_changed() -> void:
 		undo_redo.create_action("Change Character Description", 1)
 		undo_redo.add_do_property(_description_field, "text", _description_text)
 		undo_redo.add_undo_property(_description_field, "text", temp)
-		undo_redo.add_do_method(self , "_on_modified", true)
-		undo_redo.add_undo_method(self , "_on_modified", false)
+		undo_redo.add_do_method(self, "_on_modified", true)
+		undo_redo.add_undo_method(self, "_on_modified", false)
 		undo_redo.commit_action(false)
 		# ------------------------------------------------------------------
 
@@ -165,23 +168,65 @@ func _on_description_focus_exited() -> void:
 		_on_modified(true)
 
 
+#region === Editor State =======================================================
+
+## Returns the current editor state as a dictionary
+func get_editor_state() -> Dictionary:
+	return {
+		"section_visibility": {
+			"dialog_box_settings": %DialogBoxSettings.visible,
+			"portrait_settings": %PortraitSettings.visible,
+			"portrait_list": %Portraits.visible
+		},
+		"portrait_search": _portrait_search_bar.text,
+		"portrait_tree_state": _portrait_tree.get_state(),
+		"selected_portrait_path": _portrait_tree.get_selected_path()
+	}
+
+
+## Load the editor state from a dictionary
+func load_editor_state(editor_state: Dictionary) -> void:
+	if editor_state.has("section_visibility"):
+		var sections = editor_state["section_visibility"]
+		if sections.has("dialog_box_settings"):
+			_on_expand_dialog_box_button_toggled(sections["dialog_box_settings"])
+		if sections.has("portrait_settings"):
+			_on_expand_portraits_settings_button_toggled(sections["portrait_settings"])
+		if sections.has("portrait_list"):
+			_on_expand_portraits_button_toggled(sections["portrait_list"])
+
+	if editor_state.has("portrait_search"):
+		_portrait_search_bar.text = editor_state["portrait_search"]
+		_portrait_tree.filter_branch(_portrait_tree.get_root(), _portrait_search_bar.text)
+
+	if editor_state.has("portrait_tree_state"):
+		_portrait_tree.restore_state(editor_state["portrait_tree_state"])
+
+	if editor_state.has("selected_portrait_path"):
+		_portrait_tree.select_item_path(editor_state["selected_portrait_path"])
+
+
 ## Expand/hide the dialog box settings
 func _on_expand_dialog_box_button_toggled(toggled_on: bool) -> void:
 	%DialogBoxSettings.visible = toggled_on
 	%ExpandDialogBoxButton.icon = collapse_up_icon if toggled_on else collapse_down_icon
+	view_state_changed.emit(get_editor_state())
 
 
 ## Expand/hide the portrait settings
 func _on_expand_portraits_settings_button_toggled(toggled_on: bool) -> void:
 	%PortraitSettings.visible = toggled_on
 	%ExpandPortraitsSettingsButton.icon = collapse_up_icon if toggled_on else collapse_down_icon
+	view_state_changed.emit(get_editor_state())
 
 
 ## Expand/hide the portraits list
 func _on_expand_portraits_button_toggled(toggled_on: bool) -> void:
 	%Portraits.visible = toggled_on
 	%ExpandPortraitsButton.icon = collapse_up_icon if toggled_on else collapse_down_icon
+	view_state_changed.emit(get_editor_state())
 
+#endregion
 
 #region === Character Data =====================================================
 
@@ -206,7 +251,7 @@ func get_character_data() -> SproutyDialogsCharacterData:
 ## Load the character data into the editor.
 ## If name_data is provided, it will be used to load the name translations.
 ## Otherwise, the name translations will be loaded from the character data.
-func load_character(data: SproutyDialogsCharacterData, name_data: Dictionary) -> void:
+func load_character(data: SproutyDialogsCharacterData, name_data: Dictionary, editor_state: Dictionary = {}) -> void:
 	_key_name = data.key_name
 	_key_name_label.text = _key_name.to_pascal_case()
 	_description_field.text = data.description
@@ -241,6 +286,9 @@ func load_character(data: SproutyDialogsCharacterData, name_data: Dictionary) ->
 	_portrait_tree.load_portraits_data(data.portraits, _portrait_editor_scene)
 	_portrait_tree.update_portraits_transform(data.main_transform_settings)
 	_update_default_portrait_dropdown(data.default_portrait)
+
+	if editor_state and not editor_state.is_empty():
+		load_editor_state(editor_state)
 
 	_modified_counter = 0
 
@@ -347,8 +395,8 @@ func _on_default_display_name_changed(new_text: String) -> void:
 		undo_redo.create_action("Change Display Name", 1)
 		undo_redo.add_do_property(_name_default_locale_field, "text", new_text)
 		undo_redo.add_undo_property(_name_default_locale_field, "text", temp)
-		undo_redo.add_do_method(self , "_on_modified", true)
-		undo_redo.add_undo_method(self , "_on_modified", false)
+		undo_redo.add_do_method(self, "_on_modified", true)
+		undo_redo.add_undo_method(self, "_on_modified", false)
 		undo_redo.commit_action(false)
 		# ------------------------------------------------------------------
 
@@ -373,11 +421,11 @@ func _on_dialog_box_scene_path_changed(path: String) -> void:
 	undo_redo.create_action("Change Dialog Box Scene")
 	undo_redo.add_do_method(_dialog_box_scene_field, "set_scene_path", path)
 	undo_redo.add_undo_method(_dialog_box_scene_field, "set_scene_path", temp)
-	undo_redo.add_do_property(self , "_dialog_box_path", path)
-	undo_redo.add_undo_property(self , "_dialog_box_path", temp)
+	undo_redo.add_do_property(self, "_dialog_box_path", path)
+	undo_redo.add_undo_property(self, "_dialog_box_path", temp)
 	
-	undo_redo.add_do_method(self , "_on_modified", true)
-	undo_redo.add_undo_method(self , "_on_modified", false)
+	undo_redo.add_do_method(self, "_on_modified", true)
+	undo_redo.add_undo_method(self, "_on_modified", false)
 	undo_redo.commit_action(false)
 	# ----------------------------------------------------------------------
 
@@ -392,8 +440,8 @@ func _on_portrait_dialog_box_toggled(toggled_on: bool) -> void:
 	undo_redo.create_action("Toggle Portrait on Dialog Box")
 	undo_redo.add_do_property(%PortraitOnDialogBoxToggle, "button_pressed", toggled_on)
 	undo_redo.add_undo_property(%PortraitOnDialogBoxToggle, "button_pressed", temp)
-	undo_redo.add_do_method(self , "_on_modified", true)
-	undo_redo.add_undo_method(self , "_on_modified", false)
+	undo_redo.add_do_method(self, "_on_modified", true)
+	undo_redo.add_undo_method(self, "_on_modified", false)
 	undo_redo.commit_action(false)
 	# ----------------------------------------------------------------------
 
@@ -446,11 +494,11 @@ func _on_default_portrait_selected(index: int) -> void:
 	undo_redo.create_action("Select Default Portrait")
 	undo_redo.add_do_property(_default_portrait_dropdown, "selected", index)
 	undo_redo.add_undo_property(_default_portrait_dropdown, "selected", _previous_portrait_index)
-	undo_redo.add_do_property(self , "_previous_portrait_index", index)
-	undo_redo.add_undo_property(self , "_previous_portrait_index", _previous_portrait_index)
+	undo_redo.add_do_property(self, "_previous_portrait_index", index)
+	undo_redo.add_undo_property(self, "_previous_portrait_index", _previous_portrait_index)
 
-	undo_redo.add_do_method(self , "emit_signal", "modified", true)
-	undo_redo.add_undo_method(self , "emit_signal", "modified", false)
+	undo_redo.add_do_method(self, "emit_signal", "modified", true)
+	undo_redo.add_undo_method(self, "emit_signal", "modified", false)
 	undo_redo.commit_action()
 	# -----------------------------------------------------------------------
 
@@ -512,18 +560,18 @@ func _on_add_portrait_button_pressed() -> void:
 	undo_redo.create_action("Add New Portrait")
 	undo_redo.add_do_reference(item)
 	undo_redo.add_do_method(parent, "add_child", item)
-	undo_redo.add_do_property(self , "_current_portrait", item)
-	undo_redo.add_do_method(self , "_select_item_on_tree", item)
+	undo_redo.add_do_property(self, "_current_portrait", item)
+	undo_redo.add_do_method(self, "_select_item_on_tree", item)
 	
 	undo_redo.add_undo_method(parent, "remove_child", item)
-	undo_redo.add_undo_property(self , "_current_portrait", temp)
-	undo_redo.add_undo_method(self , "_select_item_on_tree", temp)
+	undo_redo.add_undo_property(self, "_current_portrait", temp)
+	undo_redo.add_undo_method(self, "_select_item_on_tree", temp)
 
-	undo_redo.add_do_method(self , "_update_default_portrait_dropdown")
-	undo_redo.add_undo_method(self , "_update_default_portrait_dropdown")
+	undo_redo.add_do_method(self, "_update_default_portrait_dropdown")
+	undo_redo.add_undo_method(self, "_update_default_portrait_dropdown")
 	
-	undo_redo.add_do_method(self , "_on_modified", true)
-	undo_redo.add_undo_method(self , "_on_modified", false)
+	undo_redo.add_do_method(self, "_on_modified", true)
+	undo_redo.add_undo_method(self, "_on_modified", false)
 	undo_redo.commit_action(false)
 	# ------------------------------------------------------------------
 
@@ -554,8 +602,8 @@ func _on_add_portrait_group_button_pressed() -> void:
 	undo_redo.add_do_reference(item)
 	undo_redo.add_do_method(parent, "add_child", item)
 	undo_redo.add_undo_method(parent, "remove_child", item)
-	undo_redo.add_do_method(self , "_on_modified", true)
-	undo_redo.add_undo_method(self , "_on_modified", false)
+	undo_redo.add_do_method(self, "_on_modified", true)
+	undo_redo.add_undo_method(self, "_on_modified", false)
 	undo_redo.commit_action(false)
 	# ------------------------------------------------------------------
 
@@ -563,6 +611,12 @@ func _on_add_portrait_group_button_pressed() -> void:
 ## Filter the portrait tree items
 func _on_portrait_search_bar_text_changed(new_text: String) -> void:
 	_portrait_tree.filter_branch(_portrait_tree.get_root(), new_text)
+	view_state_changed.emit(get_editor_state())
+
+
+## Handle the portrait tree state change
+func _on_portrait_tree_state_changed() -> void:
+	view_state_changed.emit(get_editor_state())
 
 
 ## Update the portrait settings when a portrait is selected
@@ -584,10 +638,12 @@ func _on_portrait_selected(item: TreeItem) -> void:
 	if _previous_portrait == item:
 		return # No register undoredo action
 
+	view_state_changed.emit(get_editor_state())
+
 	# --- UndoRedo ---------------------------------------------------------
 	undo_redo.create_action("Select Portrait: " + item.get_text(0))
-	undo_redo.add_do_method(self , "_select_item_on_tree", item)
-	undo_redo.add_undo_method(self , "_select_item_on_tree", _previous_portrait)
+	undo_redo.add_do_method(self, "_select_item_on_tree", item)
+	undo_redo.add_undo_method(self, "_select_item_on_tree", _previous_portrait)
 	undo_redo.commit_action(false)
 	# ----------------------------------------------------------------------
 

--- a/addons/sprouty_dialogs/editor/modules/characters/scripts/portrait_tree.gd
+++ b/addons/sprouty_dialogs/editor/modules/characters/scripts/portrait_tree.gd
@@ -19,6 +19,8 @@ signal show_portrait_editor_panel(show: bool)
 signal portrait_list_changed
 ## Emitted when the path of a portrait is changed
 signal portrait_path_changed(new_path: String, prev_path: String)
+## Emitted when the portrait tree UI state changes (selection/expanded state)
+signal portrait_tree_state_changed
 
 ## Portrait tree popup menu
 @onready var _popup_menu: PopupMenu = $PortraitPopupMenu
@@ -262,6 +264,75 @@ func filter_branch(parent: TreeItem, filter: String) -> bool:
 	return match_found
 
 
+## Returns the currently selected item's tree path, or an empty string if nothing is selected.
+func get_selected_path() -> String:
+	var selected_item := get_selected()
+	if selected_item == null:
+		return ""
+	return get_item_path(selected_item)
+
+
+## Finds a tree item by its path string, recursively searching groups.
+func find_item_by_path(path: String, from: TreeItem = get_root()) -> TreeItem:
+	for item in from.get_children():
+		if get_item_path(item) == path:
+			return item
+		if item.get_metadata(0).has("group"):
+			var found := find_item_by_path(path, item)
+			if found:
+				return found
+	return null
+
+
+## Selects a tree item by its path and emits tree-state change.
+func select_item_path(path: String) -> void:
+	if path == "":
+		return
+	var item := find_item_by_path(path)
+	if item == null:
+		return
+	deselect_all()
+	set_selected(item, 0)
+	portrait_tree_state_changed.emit()
+
+
+## Returns the current portrait tree UI state, including collapsed groups and selection.
+func get_state() -> Dictionary:
+	var state := {}
+	for item in get_root().get_children():
+		_save_item_state(item, state)
+	return {
+		"tree_items": state,
+		"selected_path": get_selected_path()
+	}
+
+
+## Restores collapse state for every item in the tree from saved state data.
+func restore_state(state: Dictionary) -> void:
+	if not state.has("tree_items"):
+		return
+	for item in get_root().get_children():
+		_restore_item_state(item, state["tree_items"])
+
+
+## Recursively saves collapse state for an item and its children.
+func _save_item_state(item: TreeItem, state: Dictionary) -> void:
+	state[get_item_path(item)] = {
+		"collapsed": item.collapsed
+	}
+	for child in item.get_children():
+		_save_item_state(child, state)
+
+
+## Recursively applies saved collapse state to tree items.
+func _restore_item_state(item: TreeItem, tree_items: Dictionary) -> void:
+	var path := get_item_path(item)
+	if tree_items.has(path):
+		item.collapsed = tree_items[path]["collapsed"]
+	for child in item.get_children():
+		_restore_item_state(child, tree_items)
+
+
 ## Update the preview of all portraits
 func update_portraits_transform(parent_transform: Dictionary, from: TreeItem = get_root()) -> void:
 	for item in from.get_children():
@@ -405,6 +476,7 @@ func _on_item_mouse_selected(mouse_position: Vector2, mouse_button_index: int) -
 ## Called when the user selects a portrait item
 func _on_item_selected() -> void:
 	portrait_item_selected.emit(get_selected())
+	portrait_tree_state_changed.emit()
 
 
 ## Called when the user double-clicks on a portrait item

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -454,6 +454,8 @@ func switch_to_selected_file(file_metadata: Dictionary) -> void:
 	elif file_metadata.data is SproutyDialogsCharacterData:
 		request_to_switch_character.emit(file_metadata["cache_node"])
 		request_to_switch_tab.emit(1)
+	
+	_save_opened_files()
 
 
 ## Switch to the file on the current tab
@@ -565,12 +567,17 @@ func _save_opened_files() -> void:
 		# Save an entry with both uid and path (path as fallback)
 		opened_files.append({"uid": uid, "path": path})
 
+	# Save the currently selected file index
+	var current_index = _file_list.get_current_index()
 	SproutyDialogsSettingsManager.set_setting("last_opened_files", opened_files)
+	SproutyDialogsSettingsManager.set_setting("last_selected_file_index", current_index)
 
 
 ## Load the list of last opened files from the project settings
 func _load_opened_files() -> void:
 	var last_opened_files = SproutyDialogsSettingsManager.get_setting("last_opened_files")
+	var last_selected_index = SproutyDialogsSettingsManager.get_setting("last_selected_file_index")
+	last_selected_index = last_selected_index if last_selected_index != null else -1
 	
 	if not (last_opened_files is Array and last_opened_files.size() > 0):
 		return
@@ -583,7 +590,12 @@ func _load_opened_files() -> void:
 		if SproutyDialogsFileUtils.check_valid_uid_path(uid):
 			var uid_path = ResourceUID.get_id_path(uid)
 			load_file(uid_path, false)
+		# If UID is not valid, try to use the path
 		elif path != "" and FileAccess.file_exists(path):
 			load_file(path, false)
 		else:
 			push_warning("[Sprouty Dialogs] File with path '" + path + "' not found. Skipping.")
+
+	# Restore the previously selected file
+	if last_selected_index >= 0 and last_selected_index < _file_list.get_item_count():
+		switch_to_selected_file(_file_list.get_item_metadata(last_selected_index))

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -268,9 +268,8 @@ func load_file(path: String, check_resources: bool = true, view_state: Dictionar
 		if resource is SproutyDialogsDialogueData:
 			SproutyDialogsFileUtils.set_recent_file_path("dialogue_files", path)
 			var graph = _new_graph_from_resource(resource)
-			if view_state.has("zoom") and view_state.has("scroll_offset"):
-					graph.zoom = view_state["zoom"]
-					graph.scroll_offset = view_state["scroll_offset"]
+			if not view_state.is_empty():
+				graph.load_editor_state(view_state)
 			var csv_path_uid = resource.csv_file_uid
 			var csv_path = ""
 			if SproutyDialogsFileUtils.check_valid_uid_path(csv_path_uid):
@@ -573,13 +572,7 @@ func _save_opened_files() -> void:
 		var uid = ResourceSaver.get_resource_id_for_path(path, true)
 		var view_state: Dictionary = {}
 		if metadata.has("cache_node") and metadata["cache_node"] != null:
-			if metadata.data is SproutyDialogsDialogueData:
-				view_state = {
-					"zoom": metadata["cache_node"].zoom,
-					"scroll_offset": metadata["cache_node"].scroll_offset
-				}
-			elif metadata.data is SproutyDialogsCharacterData:
-				view_state = metadata["cache_node"].get_editor_state()
+			view_state = metadata["cache_node"].get_editor_state()
 		# Save an entry with both uid and path (path as fallback) and view state
 		opened_files.append({"uid": uid, "path": path, "view_state": view_state})
 

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -127,6 +127,9 @@ func _ready() -> void:
 
 	await get_tree().process_frame # Wait a frame to ensure undo_redo is ready
 	_file_list.undo_redo = undo_redo
+	
+	# Load the last opened files
+	_load_opened_files()
 
 
 func _input(event: InputEvent) -> void:
@@ -186,6 +189,7 @@ func new_dialog_file(path: String) -> void:
 	request_to_switch_tab.emit(0)
 	_save_file_button.disabled = false
 	SproutyDialogsFileUtils.set_recent_file_path("dialog_files", path)
+	_save_opened_files()
 	print("[Sprouty Dialogs] Dialog file '" + path.get_file() + "' created.")
 
 
@@ -223,6 +227,7 @@ func new_character_file(path: String) -> void:
 
 	_save_file_button.disabled = false
 	SproutyDialogsFileUtils.set_recent_file_path("character_files", path)
+	_save_opened_files()
 	print("[Sprouty Dialogs] Character file '" + path.get_file() + "' created.")
 
 
@@ -251,6 +256,7 @@ func _new_character_from_resource(resource: SproutyDialogsCharacterData) -> Cont
 func load_file(path: String, check_resources: bool = true) -> void:
 	if _file_list.is_file_loaded(path):
 		_file_list.switch_to_file_path(path)
+		_save_opened_files()
 		return
 	
 	if FileAccess.file_exists(path):
@@ -267,6 +273,7 @@ func load_file(path: String, check_resources: bool = true) -> void:
 			_file_list.new_file_item(path, resource, graph, csv_path)
 			request_to_switch_tab.emit(0)
 			_save_file_button.disabled = false
+			_save_opened_files()
 			if check_resources:
 				_check_missing_characters(resource)
 		
@@ -276,6 +283,7 @@ func load_file(path: String, check_resources: bool = true) -> void:
 			_file_list.new_file_item(path, resource, char_editor)
 			request_to_switch_tab.emit(1)
 			_save_file_button.disabled = false
+			_save_opened_files()
 		
 		else:
 			printerr("[Sprouty Dialogs] File " + path + " is not a valid dialogue or character resource.")
@@ -477,6 +485,9 @@ func _on_file_closed(metadata: Dictionary) -> void:
 	# Disable save button if there are no files open
 	if _file_list.get_dialogs_count() == 0 and _file_list.get_characters_count() == 0:
 		_save_file_button.disabled = true
+	
+	# Save the updated list of opened files
+	_save_opened_files()
 
 
 ## Set the current file as modified
@@ -538,3 +549,41 @@ func _on_confirm_closing_editor_action(action) -> void:
 				save_file(index)
 		"discard_files":
 			get_tree().quit()
+
+
+## Save the list of currently opened files to the project settings
+func _save_opened_files() -> void:
+	var opened_files: Array = []
+
+	for index in range(_file_list.get_item_count()):
+		var metadata = _file_list.get_item_metadata(index)
+		if not metadata.has("file_path"):
+			continue
+		var path: String = metadata["file_path"]
+		# Try to get a stable UID for the resource
+		var uid = ResourceSaver.get_resource_id_for_path(path, true)
+		# Save an entry with both uid and path (path as fallback)
+		opened_files.append({"uid": uid, "path": path})
+
+	SproutyDialogsSettingsManager.set_setting("last_opened_files", opened_files)
+
+
+## Load the list of last opened files from the project settings
+func _load_opened_files() -> void:
+	var last_opened_files = SproutyDialogsSettingsManager.get_setting("last_opened_files")
+	
+	if not (last_opened_files is Array and last_opened_files.size() > 0):
+		return
+
+	for entry in last_opened_files:
+		var uid = entry["uid"] if entry.has("uid") else -1
+		var path = entry["path"] if entry.has("path") else ""
+
+		# Try to use UID first
+		if SproutyDialogsFileUtils.check_valid_uid_path(uid):
+			var uid_path = ResourceUID.get_id_path(uid)
+			load_file(uid_path, false)
+		elif path != "" and FileAccess.file_exists(path):
+			load_file(path, false)
+		else:
+			push_warning("[Sprouty Dialogs] File with path '" + path + "' not found. Skipping.")

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -199,6 +199,7 @@ func _new_graph_from_resource(resource: SproutyDialogsDialogueData) -> EditorSpr
 	dialogue_changed.connect(graph.dialogue_changed.emit)
 	character_changed.connect(graph.character_changed.emit)
 	graph.modified.connect(_on_data_modified)
+	graph.view_state_changed.connect(_on_graph_view_state_changed)
 	graph.undo_redo = undo_redo
 	add_child(graph)
 	var dialogs = resource.dialogs if resource.dialogs else {}
@@ -253,7 +254,7 @@ func _new_character_from_resource(resource: SproutyDialogsCharacterData) -> Cont
 #region === Save and Load ======================================================
 
 ## Load data from a dialog or character resource file
-func load_file(path: String, check_resources: bool = true) -> void:
+func load_file(path: String, check_resources: bool = true, view_state: Dictionary = {}) -> void:
 	if _file_list.is_file_loaded(path):
 		_file_list.switch_to_file_path(path)
 		_save_opened_files()
@@ -266,6 +267,9 @@ func load_file(path: String, check_resources: bool = true) -> void:
 		if resource is SproutyDialogsDialogueData:
 			SproutyDialogsFileUtils.set_recent_file_path("dialogue_files", path)
 			var graph = _new_graph_from_resource(resource)
+			if view_state.has("zoom") and view_state.has("scroll_offset"):
+					graph.zoom = view_state["zoom"]
+					graph.scroll_offset = view_state["scroll_offset"]
 			var csv_path_uid = resource.csv_file_uid
 			var csv_path = ""
 			if SproutyDialogsFileUtils.check_valid_uid_path(csv_path_uid):
@@ -564,8 +568,15 @@ func _save_opened_files() -> void:
 		var path: String = metadata["file_path"]
 		# Try to get a stable UID for the resource
 		var uid = ResourceSaver.get_resource_id_for_path(path, true)
-		# Save an entry with both uid and path (path as fallback)
-		opened_files.append({"uid": uid, "path": path})
+		var view_state: Dictionary = {}
+		if metadata.has("cache_node") and metadata["cache_node"] != null:
+			if metadata.data is SproutyDialogsDialogueData:
+				view_state = {
+					"zoom": metadata["cache_node"].zoom,
+					"scroll_offset": metadata["cache_node"].scroll_offset
+				}
+		# Save an entry with both uid and path (path as fallback) and view state
+		opened_files.append({"uid": uid, "path": path, "view_state": view_state})
 
 	# Save the currently selected file index
 	var current_index = _file_list.get_current_index()
@@ -585,17 +596,32 @@ func _load_opened_files() -> void:
 	for entry in last_opened_files:
 		var uid = entry["uid"] if entry.has("uid") else -1
 		var path = entry["path"] if entry.has("path") else ""
+		var view_state = entry["view_state"] if entry.has("view_state") else {}
 
 		# Try to use UID first
 		if SproutyDialogsFileUtils.check_valid_uid_path(uid):
 			var uid_path = ResourceUID.get_id_path(uid)
-			load_file(uid_path, false)
+			load_file(uid_path, false, view_state)
 		# If UID is not valid, try to use the path
 		elif path != "" and FileAccess.file_exists(path):
-			load_file(path, false)
+			load_file(path, false, view_state)
 		else:
 			push_warning("[Sprouty Dialogs] File with path '" + path + "' not found. Skipping.")
 
 	# Restore the previously selected file
 	if last_selected_index >= 0 and last_selected_index < _file_list.get_item_count():
 		switch_to_selected_file(_file_list.get_item_metadata(last_selected_index))
+
+
+## Handle graph view state changes and save them to the settings
+func _on_graph_view_state_changed(view_state: Dictionary) -> void:
+	var current_index = _file_list.get_current_index()
+	if current_index < 0:
+		return
+	var file_metadata = _file_list.get_item_metadata(current_index)
+	if file_metadata == null:
+		return
+	if file_metadata.has("cache_node") and file_metadata["cache_node"] != null:
+		var file_list = SproutyDialogsSettingsManager.get_setting("last_opened_files")
+		file_list[current_index]["view_state"] = view_state
+		SproutyDialogsSettingsManager.set_setting("last_opened_files", file_list)

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -199,7 +199,7 @@ func _new_graph_from_resource(resource: SproutyDialogsDialogueData) -> EditorSpr
 	dialogue_changed.connect(graph.dialogue_changed.emit)
 	character_changed.connect(graph.character_changed.emit)
 	graph.modified.connect(_on_data_modified)
-	graph.view_state_changed.connect(_on_graph_view_state_changed)
+	graph.view_state_changed.connect(_on_editor_view_state_changed)
 	graph.undo_redo = undo_redo
 	add_child(graph)
 	var dialogs = resource.dialogs if resource.dialogs else {}
@@ -236,6 +236,7 @@ func new_character_file(path: String) -> void:
 func _new_character_from_resource(resource: SproutyDialogsCharacterData) -> Control:
 	var char_editor = _char_scene.instantiate()
 	char_editor.modified.connect(_on_data_modified)
+	char_editor.view_state_changed.connect(_on_editor_view_state_changed)
 	char_editor.undo_redo = undo_redo
 	add_child(char_editor)
 	var name_data = resource.display_name if resource.display_name else {}
@@ -284,6 +285,8 @@ func load_file(path: String, check_resources: bool = true, view_state: Dictionar
 		elif resource is SproutyDialogsCharacterData:
 			SproutyDialogsFileUtils.set_recent_file_path("character_files", path)
 			var char_editor = _new_character_from_resource(resource)
+			if not view_state.is_empty():
+				char_editor.load_editor_state(view_state)
 			_file_list.new_file_item(path, resource, char_editor)
 			request_to_switch_tab.emit(1)
 			_save_file_button.disabled = false
@@ -575,6 +578,8 @@ func _save_opened_files() -> void:
 					"zoom": metadata["cache_node"].zoom,
 					"scroll_offset": metadata["cache_node"].scroll_offset
 				}
+			elif metadata.data is SproutyDialogsCharacterData:
+				view_state = metadata["cache_node"].get_editor_state()
 		# Save an entry with both uid and path (path as fallback) and view state
 		opened_files.append({"uid": uid, "path": path, "view_state": view_state})
 
@@ -613,8 +618,8 @@ func _load_opened_files() -> void:
 		switch_to_selected_file(_file_list.get_item_metadata(last_selected_index))
 
 
-## Handle graph view state changes and save them to the settings
-func _on_graph_view_state_changed(view_state: Dictionary) -> void:
+## Handle editor view state changes and save them to the settings
+func _on_editor_view_state_changed(view_state: Dictionary) -> void:
 	var current_index = _file_list.get_current_index()
 	if current_index < 0:
 		return

--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
@@ -41,6 +41,9 @@ signal nodes_selection_changed(has_selection: bool)
 ## Emitted when the selection of nodes to paste change
 signal paste_selection_changed(has_selection: bool)
 
+## Emitted when the graph zoom or scroll offset changes
+signal view_state_changed(view_state: Dictionary)
+
 ## Emitted when the toolbar is expanded
 signal toolbar_expanded
 
@@ -82,6 +85,10 @@ var _modified_counter: int = 0
 ## UndoRedo manager
 var undo_redo: EditorUndoRedoManager
 
+## Last known graph view state
+var _last_zoom: float = 1.0
+var _last_scroll_offset: Vector2 = Vector2.ZERO
+
 
 func _init() -> void:
 	node_selected.connect(_on_node_selected)
@@ -113,11 +120,25 @@ func _ready():
 	_set_node_actions_menu()
 	_set_add_node_menu()
 
+	_last_zoom = zoom
+	_last_scroll_offset = scroll_offset
+	set_process(true)
+
 
 func _input(_event):
 	if (not _add_node_menu.visible) and _request_port > -1:
 		_request_node = ""
 		_request_port = -1
+
+
+func _process(_delta: float) -> void:
+	if zoom != _last_zoom or scroll_offset != _last_scroll_offset:
+		_last_zoom = zoom
+		_last_scroll_offset = scroll_offset
+		view_state_changed.emit({
+			"zoom": zoom,
+			"scroll_offset": scroll_offset
+		})
 
 
 ## Returns all the start ids in the graph

--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
@@ -135,10 +135,27 @@ func _process(_delta: float) -> void:
 	if zoom != _last_zoom or scroll_offset != _last_scroll_offset:
 		_last_zoom = zoom
 		_last_scroll_offset = scroll_offset
-		view_state_changed.emit({
-			"zoom": zoom,
-			"scroll_offset": scroll_offset
-		})
+		view_state_changed.emit(get_editor_state())
+
+
+#region === Editor State =======================================================
+
+## Returns the current editor state as a dictionary
+func get_editor_state() -> Dictionary:
+	return {
+		"zoom": zoom,
+		"scroll_offset": scroll_offset
+	}
+
+
+## Load the editor state from a dictionary
+func load_editor_state(editor_state: Dictionary) -> void:
+	if editor_state.has("zoom"):
+		zoom = editor_state["zoom"]
+	if editor_state.has("scroll_offset"):
+		scroll_offset = editor_state["scroll_offset"]
+
+#endregion
 
 
 ## Returns all the start ids in the graph

--- a/addons/sprouty_dialogs/utils/settings_manager.gd
+++ b/addons/sprouty_dialogs/utils/settings_manager.gd
@@ -152,6 +152,10 @@ static var _settings_paths: Dictionary = {
 	"last_opened_files": {
 		"path": "sprouty_dialogs/internal/last_opened_files",
 		"default": []
+	},
+	"last_selected_file_index": {
+		"path": "sprouty_dialogs/internal/last_selected_file_index",
+		"default": - 1
 	}
 }
 

--- a/addons/sprouty_dialogs/utils/settings_manager.gd
+++ b/addons/sprouty_dialogs/utils/settings_manager.gd
@@ -148,6 +148,10 @@ static var _settings_paths: Dictionary = {
 	"play_start_id": {
 		"path": "sprouty_dialogs/internal/play_start_id",
 		"default": ""
+	},
+	"last_opened_files": {
+		"path": "sprouty_dialogs/internal/last_opened_files",
+		"default": []
 	}
 }
 


### PR DESCRIPTION
The Sprouty editor now remembers open files and restores them when it starts up! 🥳 

In addition, the editor remembers the zoom level and scroll offset (position) you were working with in the dialogue graph editor, as well as the state of the editor UI (visible sections and portrait tree) for the character editor.

- Closes #101 