### PR TITLE
Release changes 1.2.7

### DIFF
--- a/addons/sprouty_dialogs/plugin.cfg
+++ b/addons/sprouty_dialogs/plugin.cfg
@@ -3,5 +3,5 @@
 name="Sprouty Dialogs"
 description="A graph-based visual dialogue system for Godot"
 author="Sprouty Labs"
-version="1.2.6"
+version="1.2.7"
 script="plugin.gd"


### PR DESCRIPTION
## Release Changes 1.2.6 -> 1.2.7 (Patch)

- #106 
- #107 
- #108 
- #110 
- #113 
- #114 
- #115 

### Why is time for a release?

Next changes will be packed in a minor, so before that happens, we are adding a last patch to 1.2.x with everything that was in queue. Most of changes here are bug fixes, and we also feature a new editor behavior for saving your state before closing, so next time you open the plugin everything you were working on will be there!