### PR TITLE
Improve DialogPlayer API to follow Godot conventions

### DIFF
--- a/addons/sprouty_dialogs/nodes/dialog_player.gd
+++ b/addons/sprouty_dialogs/nodes/dialog_player.gd
@@ -64,15 +64,35 @@ var _start_id: String:
 			notify_property_list_changed()
 			update_configuration_warnings()
 
-## Play the dialog when the node is ready.
+## If [code]true[/code], dialog plays when the node is ready.
+## [br][br]It's the same as [member _play_on_ready], but it can be set directly on code.[br][br]
+## [i](This was added to follow the Godot conventions, without breaking existing API)
+var autoplay: bool = false:
+	set(value):
+		autoplay = value
+		_play_on_ready = value
+	get:
+		return _play_on_ready
+
+## Flag to play the dialog when the node is ready.
 var _play_on_ready: bool = false
+
+## If [code]true[/code], the [DialogPlayer] will be freed from the scene tree when the dialog ends.
+## [br] If [code]false[/code], the [DialogPlayer] will remain in the scene tree to be reused later.
+## [br][br]It's the same as [member _destroy_on_end], but it can be set directly on code.[br][br]
+## [i](This was added to follow the Godot conventions, without breaking existing API)
+var free_on_end: bool = true:
+	set(value):
+		free_on_end = value
+		_destroy_on_end = value
+	get:
+		return _destroy_on_end
 ## Flag to destroy the dialog player when the dialog ends.
-## If true, the player will be freed from the scene tree when the dialog ends.
-## If false, the player will remain in the scene tree to be reused later.
 var _destroy_on_end: bool = true
-## If true, will print debug messages to the console.
+
+## If [code]true[/code], the [DialogPlayer] will print debug messages to the console.
 ## This is used to debug the dialog processing flow while is running.
-var _print_debug: bool = false
+var print_debug: bool = false
 
 ## Array to store the start IDs of the dialogues.
 var _starts_ids: Array[String] = []
@@ -197,19 +217,19 @@ func _get_property_list():
 				"hint_string": id_list
 			})
 			props.append({
-				"name": &"_play_on_ready",
+				"name": &"autoplay",
 				"type": TYPE_BOOL,
 				"hint": PROPERTY_HINT_NONE,
 				"usage": PROPERTY_USAGE_DEFAULT
 			})
 			props.append({
-				"name": &"_destroy_on_end",
+				"name": &"free_on_end",
 				"type": TYPE_BOOL,
 				"hint": PROPERTY_HINT_NONE,
 				"usage": PROPERTY_USAGE_DEFAULT
 			})
 			props.append({
-				"name": &"_print_debug",
+				"name": &"print_debug",
 				"type": TYPE_BOOL,
 				"hint": PROPERTY_HINT_NONE,
 				"usage": PROPERTY_USAGE_DEFAULT
@@ -291,7 +311,7 @@ func _enter_tree() -> void:
 		_dialog_interpreter.dialogue_processed.connect(_on_dialogue_processed)
 		_dialog_interpreter.options_processed.connect(_on_options_processed)
 		_dialog_interpreter.jump_to_node.connect(_on_jump_to_node)
-		_dialog_interpreter.print_debug = _print_debug
+		_dialog_interpreter.print_debug = print_debug
 		add_child(_dialog_interpreter)
 
 		var sprouty_dialogs_manager = get_node("/root/SproutyDialogs")
@@ -342,17 +362,18 @@ func _ready() -> void:
 			return
 
 
-## Set play on ready flag to play the dialog when the node is ready.
-## If true, the dialog will start processing when the dialog player node is ready.
-func play_on_ready(play_on_ready: bool) -> void:
-	_play_on_ready = play_on_ready
+## If enabled, dialog plays when the node is ready.
+## @deprecated: Use [member autoplay] instead.
+func play_on_ready(enabled: bool) -> void:
+	_play_on_ready = enabled
+	autoplay = enabled
 
 
-## Set the flag to destroy the dialog player when the dialog ends.
-## If true, the player will be freed from the scene tree when the dialog ends.
-## If false, the player will remain in the scene tree to be reused later.
-func destroy_on_end(destroy: bool) -> void:
-	_destroy_on_end = destroy
+## If enabled, the [DialogPlayer] will be freed from the scene tree when the dialog ends.
+## [br]Otherwise, the [DialogPlayer] will remain in the scene tree to be reused later.
+## @deprecated: Use [member free_on_end] instead.
+func destroy_on_end(enabled: bool) -> void:
+	_destroy_on_end = enabled
 
 
 ## Returns the dialogue data resource being processed
@@ -365,41 +386,6 @@ func get_start_id() -> String:
 	if _start_id == "(Select a dialog)":
 		return ""
 	return _start_id
-
-
-## Returns the name of the start node for a given dialog branch.
-func _get_start_node_name(dialog_id: String) -> String:
-	if not _dialog_data or not _dialog_data.graph_data.has(dialog_id):
-		return ""
-	for node_name in _dialog_data.graph_data[dialog_id].keys():
-		if _dialog_data.graph_data[dialog_id][node_name]["node_type"] == "start_node":
-			return node_name
-	return ""
-
-
-## Load the resources for a given dialog branch.
-func _load_dialog_resources(dialog_id: String) -> void:
-	if not _dialog_data or not _starts_ids.has(dialog_id):
-		return
-	_resource_manager.load_resources(_dialog_data, dialog_id)
-	_loaded_dialog_ids.append(dialog_id)
-	for node in _dialog_data.graph_data[dialog_id].keys():
-		if _dialog_data.graph_data[dialog_id][node].has("to_dialog"):
-			# If the node has a reference to another dialog, load its resources too
-			var to_dialog = _dialog_data.graph_data[dialog_id][node]["to_dialog"]
-			if to_dialog != "" and to_dialog != dialog_id:
-				_resource_manager.load_resources(_dialog_data, to_dialog)
-				_loaded_dialog_ids.append(to_dialog)
-
-
-## Release all resources that were loaded for the active dialog branches.
-func _release_dialog_resources() -> void:
-	if not _resource_manager or not _dialog_data:
-		_loaded_dialog_ids.clear()
-		return
-	for dialog_id in _loaded_dialog_ids:
-		_resource_manager.release_resources(_dialog_data, dialog_id)
-	_loaded_dialog_ids.clear()
 
 
 ## Returns character data for a given character key name
@@ -449,9 +435,51 @@ func set_dialog(data: SproutyDialogsDialogueData, start_id: String,
 	_load_dialog_resources(_start_id)
 
 
+## Returns the name of the start node for a given dialog branch.
+func _get_start_node_name(dialog_id: String) -> String:
+	if not _dialog_data or not _dialog_data.graph_data.has(dialog_id):
+		return ""
+	for node_name in _dialog_data.graph_data[dialog_id].keys():
+		if _dialog_data.graph_data[dialog_id][node_name]["node_type"] == "start_node":
+			return node_name
+	return ""
+
+
+## Load the resources for a given dialog branch.
+func _load_dialog_resources(dialog_id: String) -> void:
+	if not _dialog_data or not _starts_ids.has(dialog_id):
+		return
+	_resource_manager.load_resources(_dialog_data, dialog_id)
+	_loaded_dialog_ids.append(dialog_id)
+	for node in _dialog_data.graph_data[dialog_id].keys():
+		if _dialog_data.graph_data[dialog_id][node].has("to_dialog"):
+			# If the node has a reference to another dialog, load its resources too
+			var to_dialog = _dialog_data.graph_data[dialog_id][node]["to_dialog"]
+			if to_dialog != "" and to_dialog != dialog_id:
+				_resource_manager.load_resources(_dialog_data, to_dialog)
+				_loaded_dialog_ids.append(to_dialog)
+
+
+## Release all resources that were loaded for the active dialog branches.
+func _release_dialog_resources() -> void:
+	if not _resource_manager or not _dialog_data:
+		_loaded_dialog_ids.clear()
+		return
+	for dialog_id in _loaded_dialog_ids:
+		_resource_manager.release_resources(_dialog_data, dialog_id)
+	_loaded_dialog_ids.clear()
+
+
 #region === Run dialog =========================================================
 
-## Start processing a dialog tree
+## Plays the dialog tree.
+## [br][br]It's the same as calling the [method start()] method.[br][br]
+## [i](This was added to follow the Godot conventions, without breaking existing API).
+func play() -> void:
+	start()
+
+
+## Start processing the dialog tree.
 ## Need to set the [member _dialog_data] and [member _start_id] 
 ## before calling this method. The resources are loaded on the [method _ready()] method,
 func start() -> void:
@@ -466,7 +494,7 @@ func start() -> void:
 	# Search for start node and start processing from there
 	for node in _dialog_data.graph_data[_start_id]:
 		if node.contains("start_node"):
-			if _print_debug:
+			if print_debug:
 				print("[Sprouty Dialogs] Starting dialog with ID: " + _start_id)
 			_is_running = true
 			_process_node(node)
@@ -476,7 +504,7 @@ func start() -> void:
 
 ## Pause processing the dialog tree
 func pause() -> void:
-	if _print_debug: print("[Sprouty Dialogs] Dialog paused.")
+	if print_debug: print("[Sprouty Dialogs] Dialog paused.")
 	_is_running = false
 	# If there is a current dialog box, pause it
 	if _current_dialog_box:
@@ -491,7 +519,7 @@ func pause() -> void:
 
 ## Resume processing the dialog tree
 func resume() -> void:
-	if _print_debug: print("[Sprouty Dialogs] Dialog resumed.")
+	if print_debug: print("[Sprouty Dialogs] Dialog resumed.")
 	_is_running = true
 	# If there is a current dialog box, resume it
 	if _current_dialog_box:
@@ -507,7 +535,7 @@ func resume() -> void:
 
 ## Stop processing the dialog tree
 func stop() -> void:
-	if _print_debug: print("[Sprouty Dialogs] Dialog ended.")
+	if print_debug: print("[Sprouty Dialogs] Dialog ended.")
 	_is_running = false
 	_jump_stack.clear()
 	_current_portrait = null

--- a/addons/sprouty_dialogs/nodes/dialog_player.gd
+++ b/addons/sprouty_dialogs/nodes/dialog_player.gd
@@ -67,7 +67,8 @@ var _start_id: String:
 			update_configuration_warnings()
 
 ## If [code]true[/code], dialog plays when the node is ready.
-## [br][br]It's the same as [member _play_on_ready], but it can be set directly on code.[br][br]
+##
+## [br][br]It's the same as [method play_on_ready].[br][br]
 ## [i](This was added to follow the Godot conventions, without breaking existing API)
 var autoplay: bool = false:
 	set(value):
@@ -81,7 +82,8 @@ var _play_on_ready: bool = false
 
 ## If [code]true[/code], the [DialogPlayer] will be freed from the scene tree when the dialog ends.
 ## [br] If [code]false[/code], the [DialogPlayer] will remain in the scene tree to be reused later.
-## [br][br]It's the same as [member _destroy_on_end], but it can be set directly on code.[br][br]
+##
+## [br][br]It's the same as [method destroy_on_end].[br][br]
 ## [i](This was added to follow the Godot conventions, without breaking existing API)
 var free_on_end: bool = true:
 	set(value):
@@ -365,7 +367,7 @@ func _ready() -> void:
 			_load_dialog_resources(_start_id)
 			# Start processing the dialog tree if the play on ready is enabled
 			if _play_on_ready:
-				start()
+				play()
 		elif _start_id == "(Select a dialog)":
 			printerr("[Sprouty Dialogs] No dialog ID selected to play.")
 			return
@@ -418,7 +420,7 @@ func get_current_dialog_box() -> DialogBox:
 
 ## Set the dialogue data and start ID to play a dialog tree.
 ## This method loads the dialog resources and prepares the player to process
-## the dialog tree before calling the [method start()] method.
+## the dialog tree before calling the [method start] method.
 func set_dialog(data: SproutyDialogsDialogueData, start_id: String,
 		portrait_parents: Dictionary = {}, dialog_box_parents: Dictionary = {}) -> void:
 	if not data:
@@ -482,15 +484,20 @@ func _release_dialog_resources() -> void:
 #region === Run dialog =========================================================
 
 ## Plays the dialog tree.
-## [br][br]It's the same as calling the [method start()] method.[br][br]
+## [br][br]Need to set the [member _dialog_data] and [member _start_id] before calling this method. 
+## The resources are loaded on the [method _ready] method.
+##
+## [br][br]It's the same as [method start].[br][br]
 ## [i](This was added to follow the Godot conventions, without breaking existing API).
 func play() -> void:
 	start()
 
 
 ## Start processing the dialog tree.
-## Need to set the [member _dialog_data] and [member _start_id] 
-## before calling this method. The resources are loaded on the [method _ready()] method,
+## [br][br]Need to set the [member _dialog_data] and [member _start_id] before calling this method.
+## The resources are loaded on the [method _ready] method.[br][br]
+##
+## @deprecated: Use [method play] instead.
 func start() -> void:
 	if not _dialog_data: # Check if dialogue data is set
 		printerr("[Sprouty Dialogs] No dialogue data set to play.")

--- a/addons/sprouty_dialogs/nodes/dialog_player.gd
+++ b/addons/sprouty_dialogs/nodes/dialog_player.gd
@@ -35,6 +35,8 @@ signal dialog_player_stop()
 ## Name of the dialogue data file being played.
 @export_storage var _dialog_file_name: String = ""
 
+#region === Editor Properties ================================================== 
+
 ## Dialogue data resource to play.
 var _dialog_data: SproutyDialogsDialogueData:
 	set(value):
@@ -94,8 +96,9 @@ var _destroy_on_end: bool = true
 ## This is used to debug the dialog processing flow while is running.
 var print_debug: bool = false
 
-## Array to store the start IDs of the dialogues.
-var _starts_ids: Array[String] = []
+#endregion
+
+#region === Dictionaries =======================================================
 
 ## Dictionary to store the portrait parent nodes by character.
 ## The keys are character names and the values are the parent nodes where
@@ -147,6 +150,11 @@ var _dialog_box_instances: Dictionary = {}
 ## }[/codeblock]
 var _portraits_instances: Dictionary = {}
 
+#endregion
+
+## Array to store the start IDs of the dialogues.
+var _starts_ids: Array[String] = []
+
 ## Dialog interpreter instance to process the dialog nodes.
 var _dialog_interpreter: SproutyDialogsEventInterpreter
 ## Resource manager instance used to load resources for the dialogs.
@@ -159,6 +167,7 @@ var _current_portrait: DialogPortrait
 
 ## Next nodes options to process when a dialog option is selected.
 var _next_options: Array = []
+## Current dialog option keys
 var _current_option_keys: Array = []
 ## Next node to process in the dialog tree after a dialogue node.
 var _next_node: String = ""
@@ -177,7 +186,7 @@ var _current_node: String = ""
 var _is_running: bool = false
 
 
-#region === Editor properties ==================================================
+#region === Handle Editor Properties ===========================================
 
 ## Handle editor warnings
 func _get_configuration_warnings() -> PackedStringArray:

--- a/addons/sprouty_dialogs/sprouty_dialogs_manager.gd
+++ b/addons/sprouty_dialogs/sprouty_dialogs_manager.gd
@@ -26,8 +26,8 @@ signal option_selected(option_index: int, option_dialog: Dictionary)
 ## Emitted when a signal event is emitted.
 signal signal_event(signal_id: String, args: Array)
 
-## The list of dialog players currently running.
-## This is used to keep track of multiple dialog players running at the same time.
+## The list of [DialogPlayer]s currently running.
+## This is used to keep track of multiple [DialogPlayer]s running at the same time.
 var dialog_players_running: Array[DialogPlayer] = []
 
 ## Resource manager singleton instance
@@ -41,7 +41,7 @@ var Settings := SproutyDialogsSettingsManager
 func _ready():
 	# Make the manager available as a singleton
 	if not Engine.has_singleton("SproutyDialogs"):
-		Engine.register_singleton("SproutyDialogs", self )
+		Engine.register_singleton("SproutyDialogs", self)
 
 	# Set managers instances
 	Variables.name = "VariablesManager"
@@ -50,27 +50,40 @@ func _ready():
 	add_child(Resources)
 
 
-#region === Run dialog =========================================================
-## Start a dialog with the given data and start ID.
-## This will create a new dialog player instance and start it.
-## Also, [b]will load the resources needed for the dialog, such as characters, 
-## dialog boxes, and portraits, before starting the dialog player.[/b][br][br]
+#region === Play dialog ========================================================
+
+## Play a dialog with the given data and start ID.
+## [br]This will create a new [DialogPlayer] instance and play it.
 ##
-## [color=red][b]This may cause a slowdown if resources are large.[/b][/color]
-## It is recommended to start the dialog from a previously created
-## [DialogPlayer] instance instead of calling this method from here. 
-## The dialog player will handle the resource loading on _ready(), loading the
-## resources only once and reusing them for the dialog.
+## [br][br]This method also [b]loads all the resources needed for the dialogue at
+## once[/b] when the method is called, [color=tomato][b]so may cause a slowdown if
+## you have large resources to load.[/b][/color]
+##
+## [br][br]It's the same as [method start_dialog].[br][br]
+## [i](This was added to follow the Godot conventions, without breaking existing API).
+func play(data: SproutyDialogsDialogueData, start_id: String,
+		portrait_parents: Dictionary = {}, dialog_box_parents: Dictionary = {}) -> DialogPlayer:
+	return start_dialog(data, start_id, portrait_parents, dialog_box_parents)
+
+
+## Start a dialog with the given data and start ID.
+## [br]This will create a new [DialogPlayer] instance and play it.
+##
+## [br][br]This method also [b]loads all the resources needed for the dialogue at
+## once[/b] when the method is called, [color=tomato][b]so may cause a slowdown if
+## you have large resources to load.[/b][/color]
+##
+## @deprecated: Use [method play] instead.
 func start_dialog(data: SproutyDialogsDialogueData, start_id: String,
 		portrait_parents: Dictionary = {}, dialog_box_parents: Dictionary = {}) -> DialogPlayer:
 	# Create a new dialog player instance
 	var new_dialog_player = DialogPlayer.new()
-	new_dialog_player.destroy_on_end(true)
+	new_dialog_player.free_on_end = true
 	add_child(new_dialog_player)
 
 	# Set the dialogue data and start running the dialog
 	new_dialog_player.set_dialog(data, start_id, portrait_parents, dialog_box_parents)
-	new_dialog_player.start()
+	new_dialog_player.play()
 	return new_dialog_player
 
 #endregion


### PR DESCRIPTION
This PR add some improvements to the DialogPlayer:

- Adds `play()`method as a wrapper of `start()` to follow the Godot conventions.
   - In consequence, now `start()` method is ***deprecated***, instead use `play()`.
- Replace `_play_on_ready` for `autoplay` to follow the Godot conventions and reduce unnecessary redundancy.
    - In consequence, now `play_on_ready()` method is ***deprecated***, instead use `autoplay=true/false`.
- Replace `_destroy_on_end` for `free_on_end` for the same reason.
    - In consequence, now `destroy_on_end()` method is ***deprecated***, instead use `free_on_end=true/false`.

The `play()` method has also been added to Sprouty Dialogs Autoload, making the `start_dialog()` method deprecated too.

The deprecated methods will be **removed and replaced** for the new properties in a **future major release (2.0)**. Although you can still use them, it is strongly recommended that you replace them now.

>[!IMPORTANT]
>These changes will not cause you to lose your previous settings, since your `_play_on_ready` and `_destroy_on_end` settings will be reflected in the new properties.

- Closes #103 