### PR TITLE
 Add middle-click file closing in the file manager

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_list_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_list_manager.gd
@@ -58,7 +58,7 @@ func _ready():
 	_file_list.item_selected.connect(_on_file_selected)
 	_file_list.item_clicked.connect(_on_item_clicked)
 
-	_filtered_list.item_selected.connect(_on_file_selected)
+	_filtered_list.item_selected.connect(_on_filtered_item_selected)
 	_filtered_list.item_clicked.connect(_on_item_clicked)
 
 	_file_popup_menu.id_pressed.connect(_on_file_menu_pressed)
@@ -221,11 +221,11 @@ func close_file(index: int = _current_file_index) -> void:
 	
 	_file_list.remove_item(index)
 	if _filtered_list.visible:
-		if _file_search.text.is_empty():
-			_filtered_list.hide()
-			_file_list.show()
-		else:
-			_filter_file_list(_file_search.text)
+		_filter_file_list(_file_search.text)
+		for item in _filtered_list.item_count:
+			if int(_filtered_list.get_item_metadata(item)) == _current_file_index:
+				_filtered_list.select(item)
+				break
 	file_closed.emit(metadata)
 
 
@@ -322,9 +322,13 @@ func _switch_to_file(index: int) -> void:
 	file_selected.emit(_file_list.get_item_metadata(index))
 
 
+## Handle selection of a filtered list item
+func _on_filtered_item_selected(index: int) -> void:
+	_on_file_selected(_get_file_index_from_visible_item(index))
+
+
 ## Handle file selection from the file list
 func _on_file_selected(index: int) -> void:
-	index = _get_file_index_from_visible_item(index)
 	if index < 0:
 		return
 	var temp = _current_file_index
@@ -355,7 +359,7 @@ func _on_item_clicked(index: int, at_pos: Vector2, mouse_button_index: int) -> v
 			close_file(file_index)
 		MOUSE_BUTTON_RIGHT:
 			_last_clicked_item = file_index
-			_on_file_selected(index)
+			_on_file_selected(file_index)
 			_display_item_contextual_menu(at_pos, mouse_button_index)
 
 

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_list_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_list_manager.gd
@@ -220,6 +220,12 @@ func close_file(index: int = _current_file_index) -> void:
 	_characters_count -= 1 if metadata.data is SproutyDialogsCharacterData else 0
 	
 	_file_list.remove_item(index)
+	if _filtered_list.visible:
+		if _file_search.text.is_empty():
+			_filtered_list.hide()
+			_file_list.show()
+		else:
+			_filter_file_list(_file_search.text)
 	file_closed.emit(metadata)
 
 
@@ -269,12 +275,22 @@ func _filter_file_list(search_text: String) -> void:
 	
 	for item in _file_list.item_count:
 		if _file_list.get_item_text(item).contains(search_text):
-			_filtered_list.add_item(
+			var filtered_index := _filtered_list.add_item(
 				_file_list.get_item_text(item),
 				_file_list.get_item_icon(item)
 			)
+			_filtered_list.set_item_metadata(filtered_index, item)
 	_file_list.hide()
 	_filtered_list.show()
+
+
+## Resolve visible list item indexes back to the backing file list.
+func _get_file_index_from_visible_item(index: int) -> int:
+	if _filtered_list.visible:
+		if index < 0 or index >= _filtered_list.item_count:
+			return -1
+		return int(_filtered_list.get_item_metadata(index))
+	return index
 
 
 ## Update metadata for a file in the file list
@@ -308,6 +324,9 @@ func _switch_to_file(index: int) -> void:
 
 ## Handle file selection from the file list
 func _on_file_selected(index: int) -> void:
+	index = _get_file_index_from_visible_item(index)
+	if index < 0:
+		return
 	var temp = _current_file_index
 	_switch_to_file(index)
 
@@ -325,13 +344,19 @@ func _display_item_contextual_menu(at_pos: Vector2, mouse_button_index: int) -> 
 	_file_popup_menu.popup(Rect2(pos, _file_popup_menu.size))
 
 
-## When a file is right clicked, show the file menu options and select the file
+## When a file is clicked, handle file mouse shortcuts.
 func _on_item_clicked(index: int, at_pos: Vector2, mouse_button_index: int) -> void:
-	_last_clicked_item = index
-	_on_file_selected(index)
+	var file_index := _get_file_index_from_visible_item(index)
+	if file_index < 0:
+		return
 
-	if mouse_button_index == MOUSE_BUTTON_RIGHT:
-		_display_item_contextual_menu(at_pos, mouse_button_index)
+	match mouse_button_index:
+		MOUSE_BUTTON_MIDDLE:
+			close_file(file_index)
+		MOUSE_BUTTON_RIGHT:
+			_last_clicked_item = file_index
+			_on_file_selected(index)
+			_display_item_contextual_menu(at_pos, mouse_button_index)
 
 
 ## Set the file menu options


### PR DESCRIPTION
Body:
## Summary
- Middle-clicking a file in the file list (or in the filtered search results) now closes it; left-click selection and the right-click context menu behave
as before.
- Filtered search results now map back to the correct file: filtered list items store their backing file index, so clicking, closing, or selecting a file
while a search filter is active targets the right file.
- After closing a file while filtering, the filtered list refreshes and re-selects the current file; an unreachable branch in `close_file` was removed.

Only `addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_list_manager.gd` is changed.

## Testing
Manually verified in the Godot editor: middle-click closing in both the normal and filtered lists, opening loaded/new files while a filter is active, and
left/right-click selection and context menu targeting.