### PR TITLE
Add file reload to the file manager

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/file_manager/file_manager.tscn
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/file_manager.tscn
@@ -177,6 +177,12 @@ size = Vector2i(336, 106)
 dialog_text = "The file/s contains unsaved changes. 
 Are you sure you want to close this file/s?"
 
+[node name="ReloadDialogText" type="Label" parent="ContentContainer/Container/FileManager/PopupDialogs"]
+unique_name_in_owner = true
+visible = false
+text = "The file/s contains unsaved changes.
+Are you sure you want to reload this file/s?"
+
 [node name="CloseEditorWarning" type="AcceptDialog" parent="ContentContainer/Container/FileManager/PopupDialogs" unique_id=913469440]
 unique_name_in_owner = true
 oversampling_override = 1.0

--- a/addons/sprouty_dialogs/editor/modules/file_manager/file_manager.tscn
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/file_manager.tscn
@@ -144,7 +144,7 @@ file_filters = PackedStringArray("*.csv")
 [node name="FileMenu" type="PopupMenu" parent="ContentContainer/Container/FileManager/PopupDialogs" unique_id=1188413652]
 unique_name_in_owner = true
 size = Vector2i(108, 120)
-item_count = 5
+item_count = 8
 item_0/text = "Save"
 item_0/icon = SubResource("DPITexture_lvb0l")
 item_0/id = 0
@@ -153,12 +153,20 @@ item_1/icon = SubResource("DPITexture_lvb0l")
 item_1/id = 1
 item_2/id = 4
 item_2/separator = true
-item_3/text = "Close"
+item_3/text = "Reload"
 item_3/icon = SubResource("DPITexture_lvb0l")
-item_3/id = 2
-item_4/text = "Close All"
+item_3/id = 5
+item_4/text = "Reload All"
 item_4/icon = SubResource("DPITexture_lvb0l")
-item_4/id = 3
+item_4/id = 6
+item_5/id = 7
+item_5/separator = true
+item_6/text = "Close"
+item_6/icon = SubResource("DPITexture_lvb0l")
+item_6/id = 2
+item_7/text = "Close All"
+item_7/icon = SubResource("DPITexture_lvb0l")
+item_7/id = 3
 
 [node name="ConfirmCloseFiles" type="AcceptDialog" parent="ContentContainer/Container/FileManager/PopupDialogs" unique_id=1858451831]
 unique_name_in_owner = true

--- a/addons/sprouty_dialogs/editor/modules/file_manager/file_manager.tscn
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/file_manager.tscn
@@ -181,7 +181,7 @@ Are you sure you want to close this file/s?"
 unique_name_in_owner = true
 visible = false
 text = "The file/s contains unsaved changes.
-Are you sure you want to reload this file/s?"
+Are you sure you want to reload this file/s from disk?"
 
 [node name="CloseEditorWarning" type="AcceptDialog" parent="ContentContainer/Container/FileManager/PopupDialogs" unique_id=913469440]
 unique_name_in_owner = true

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_list_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_list_manager.gd
@@ -17,6 +17,11 @@ signal file_closed(metadata: Dictionary)
 signal request_save_file(index: int)
 ## Emitted when requesting to save a file as.
 signal request_save_file_as(index: int)
+## Emitted when requesting to reload a file from disk.
+signal request_reload_file(index: int)
+
+## Confirmation dialog text shown when reloading files with unsaved changes
+const RELOAD_DIALOG_TEXT := "The file/s contains unsaved changes.\nAre you sure you want to reload this file/s?"
 
 ## File search input
 @onready var _file_search: LineEdit = $FileSearch
@@ -40,6 +45,12 @@ var _current_file_index: int = -1
 var _closing_queue: Array[int] = []
 ## Flag to indicate if all files are being closed
 var _is_closing_all: bool = false
+## Flag to indicate if files are being reloaded instead of closed
+var _is_reloading: bool = false
+## Save button of the confirm dialog, hidden when reloading files
+var _confirm_save_button: Button
+## Confirm dialog text used when closing files
+var _close_dialog_text: String
 
 ## Number of dialogs in the file list
 var _dialogs_count: int = 0
@@ -68,15 +79,18 @@ func _ready():
 	# Set icons for buttons
 	_file_popup_menu.set_item_icon(0, get_theme_icon("Save", "EditorIcons"))
 	_file_popup_menu.set_item_icon(1, get_theme_icon("Save", "EditorIcons"))
-	_file_popup_menu.set_item_icon(3, get_theme_icon("Close", "EditorIcons"))
-	_file_popup_menu.set_item_icon(4, get_theme_icon("Close", "EditorIcons"))
+	_file_popup_menu.set_item_icon(3, get_theme_icon("Reload", "EditorIcons"))
+	_file_popup_menu.set_item_icon(4, get_theme_icon("Reload", "EditorIcons"))
+	_file_popup_menu.set_item_icon(6, get_theme_icon("Close", "EditorIcons"))
+	_file_popup_menu.set_item_icon(7, get_theme_icon("Close", "EditorIcons"))
 	_file_search.right_icon = get_theme_icon("Search", "EditorIcons")
 
 	# Set confirm closing dialog actions
 	_confirm_close_dialog.get_ok_button().hide()
-	_confirm_close_dialog.add_button('Save', true, 'save_file')
+	_confirm_save_button = _confirm_close_dialog.add_button('Save', true, 'save_file')
 	_confirm_close_dialog.add_button('Discard', true, 'discard_file')
 	_confirm_close_dialog.add_cancel_button('Cancel')
+	_close_dialog_text = _confirm_close_dialog.dialog_text
 
 
 ## Returns the current file index
@@ -193,7 +207,7 @@ func close_file(index: int = _current_file_index) -> void:
 	if metadata["modified"] and not index in _closing_queue:
 		_is_closing_all = false
 		_closing_queue.append(index)
-		_confirm_close_dialog.popup_centered()
+		_popup_unsaved_files_dialog(false)
 		return
 
 	# If the file to be closed is being edited
@@ -239,14 +253,50 @@ func close_all() -> void:
 			_closing_queue.append(index)
 	
 	if _closing_queue.size() > 0: # Alert unsaved changes
-		_confirm_close_dialog.popup_centered()
+		_popup_unsaved_files_dialog(false)
 		_is_closing_all = true
 		return
-	
+
 	# Close all if none are modified
 	for index in range(_file_list.item_count):
 		close_file(index)
 	_current_file_index = -1
+
+
+## Reload an open file from disk, discarding any unsaved changes
+func reload_file(index: int = _current_file_index) -> void:
+	if _file_list.item_count == 0: return
+
+	index = wrapi(index, 0, _file_list.item_count)
+	var metadata := _file_list.get_item_metadata(index)
+
+	# If the file to be reloaded is unsaved, alert user before reload
+	if metadata["modified"] and not index in _closing_queue:
+		_is_closing_all = false
+		_closing_queue.append(index)
+		_popup_unsaved_files_dialog(true)
+		return
+
+	request_reload_file.emit(index)
+
+
+## Reload all open files from disk, discarding any unsaved changes
+func reload_all() -> void:
+	_closing_queue.clear()
+
+	# Add unsaved files to queue to wait for reload confirmation
+	for index in range(_file_list.item_count):
+		if _file_list.get_item_metadata(index)["modified"]:
+			_closing_queue.append(index)
+
+	if _closing_queue.size() > 0: # Alert unsaved changes
+		_popup_unsaved_files_dialog(true)
+		_is_closing_all = true
+		return
+
+	# Reload all if none are modified
+	for index in range(_file_list.item_count):
+		request_reload_file.emit(index)
 
 
 ## Set a file as modified or unsaved
@@ -374,9 +424,22 @@ func _on_file_menu_pressed(id: int) -> void:
 			close_file() # Close current file
 		3:
 			close_all() # Close all files
+		5:
+			reload_file() # Reload current file
+		6:
+			reload_all() # Reload all files
 	
 
 	_last_clicked_item = -1
+
+
+## Show the unsaved changes confirmation dialog for closing or reloading files
+func _popup_unsaved_files_dialog(reloading: bool) -> void:
+	_is_reloading = reloading
+	_confirm_close_dialog.dialog_text = RELOAD_DIALOG_TEXT if reloading else _close_dialog_text
+	_confirm_save_button.visible = not reloading
+	_confirm_close_dialog.popup_centered()
+
 
 ## Set the confirm closing dialog actions
 func _on_confirm_closing_action(action) -> void:
@@ -396,18 +459,26 @@ func _on_confirm_closing_action(action) -> void:
 		"discard_file":
 			for index in _closing_queue:
 				set_file_as_modified(index, false)
-			if _is_closing_all:
+			if _is_reloading:
+				if _is_closing_all:
+					reload_all()
+				else:
+					for index in _closing_queue:
+						reload_file(index)
+			elif _is_closing_all:
 				close_all()
 			else:
 				for index in _closing_queue:
 					close_file(index)
 	_closing_queue.clear()
 	_is_closing_all = false
+	_is_reloading = false
 
 
 ## Cancel the closing confirmation dialog
 func _on_confirm_closing_canceled() -> void:
 	_closing_queue.clear()
+	_is_reloading = false
 
 
 ## Filter the file list by the input search text

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_list_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_list_manager.gd
@@ -20,9 +20,6 @@ signal request_save_file_as(index: int)
 ## Emitted when requesting to reload a file from disk.
 signal request_reload_file(index: int)
 
-## Confirmation dialog text shown when reloading files with unsaved changes
-const RELOAD_DIALOG_TEXT := "The file/s contains unsaved changes.\nAre you sure you want to reload this file/s?"
-
 ## File search input
 @onready var _file_search: LineEdit = $FileSearch
 ## File list on side bar
@@ -43,14 +40,15 @@ var _char_icon := preload("res://addons/sprouty_dialogs/editor/icons/character.s
 var _current_file_index: int = -1
 ## Files to close queue
 var _closing_queue: Array[int] = []
-## Flag to indicate if all files are being closed
-var _is_closing_all: bool = false
-## Flag to indicate if files are being reloaded instead of closed
-var _is_reloading: bool = false
+## Pending file operation awaiting confirmation in the unsaved-changes dialog
+enum PendingAction { NONE, CLOSE, CLOSE_ALL, RELOAD, RELOAD_ALL }
+var _pending_action: PendingAction = PendingAction.NONE
 ## Save button of the confirm dialog, hidden when reloading files
 var _confirm_save_button: Button
 ## Confirm dialog text used when closing files
 var _close_dialog_text: String
+## Confirm dialog text used when reloading files
+var _reload_dialog_text: String
 
 ## Number of dialogs in the file list
 var _dialogs_count: int = 0
@@ -91,6 +89,7 @@ func _ready():
 	_confirm_close_dialog.add_button('Discard', true, 'discard_file')
 	_confirm_close_dialog.add_cancel_button('Cancel')
 	_close_dialog_text = _confirm_close_dialog.dialog_text
+	_reload_dialog_text = %ReloadDialogText.text
 
 
 ## Returns the current file index
@@ -205,9 +204,8 @@ func close_file(index: int = _current_file_index) -> void:
 
 	# If the file to be closed is unsaved, alert user before close
 	if metadata["modified"] and not index in _closing_queue:
-		_is_closing_all = false
 		_closing_queue.append(index)
-		_popup_unsaved_files_dialog(false)
+		_popup_unsaved_files_dialog(PendingAction.CLOSE)
 		return
 
 	# If the file to be closed is being edited
@@ -253,8 +251,7 @@ func close_all() -> void:
 			_closing_queue.append(index)
 	
 	if _closing_queue.size() > 0: # Alert unsaved changes
-		_popup_unsaved_files_dialog(false)
-		_is_closing_all = true
+		_popup_unsaved_files_dialog(PendingAction.CLOSE_ALL)
 		return
 
 	# Close all if none are modified
@@ -272,9 +269,8 @@ func reload_file(index: int = _current_file_index) -> void:
 
 	# If the file to be reloaded is unsaved, alert user before reload
 	if metadata["modified"] and not index in _closing_queue:
-		_is_closing_all = false
 		_closing_queue.append(index)
-		_popup_unsaved_files_dialog(true)
+		_popup_unsaved_files_dialog(PendingAction.RELOAD)
 		return
 
 	request_reload_file.emit(index)
@@ -290,8 +286,7 @@ func reload_all() -> void:
 			_closing_queue.append(index)
 
 	if _closing_queue.size() > 0: # Alert unsaved changes
-		_popup_unsaved_files_dialog(true)
-		_is_closing_all = true
+		_popup_unsaved_files_dialog(PendingAction.RELOAD_ALL)
 		return
 
 	# Reload all if none are modified
@@ -434,24 +429,25 @@ func _on_file_menu_pressed(id: int) -> void:
 
 
 ## Show the unsaved changes confirmation dialog for closing or reloading files
-func _popup_unsaved_files_dialog(reloading: bool) -> void:
-	_is_reloading = reloading
-	_confirm_close_dialog.dialog_text = RELOAD_DIALOG_TEXT if reloading else _close_dialog_text
+func _popup_unsaved_files_dialog(action: PendingAction) -> void:
+	_pending_action = action
+	var reloading := action in [PendingAction.RELOAD, PendingAction.RELOAD_ALL]
+	_confirm_close_dialog.dialog_text = _reload_dialog_text if reloading else _close_dialog_text
 	_confirm_save_button.visible = not reloading
 	_confirm_close_dialog.popup_centered()
 
 
 ## Set the confirm closing dialog actions
-func _on_confirm_closing_action(action) -> void:
+func _on_confirm_closing_action(dialog_action) -> void:
 	_confirm_close_dialog.hide()
 	if _closing_queue.size() == 0:
 		return
 	
-	match action:
+	match dialog_action:
 		"save_file":
 			for index in _closing_queue:
 				request_save_file.emit(index)
-			if _is_closing_all:
+			if _pending_action == PendingAction.CLOSE_ALL:
 				close_all()
 			else:
 				for index in _closing_queue:
@@ -459,26 +455,27 @@ func _on_confirm_closing_action(action) -> void:
 		"discard_file":
 			for index in _closing_queue:
 				set_file_as_modified(index, false)
-			if _is_reloading:
-				if _is_closing_all:
+			match _pending_action:
+				PendingAction.RELOAD_ALL:
 					reload_all()
-				else:
+				PendingAction.RELOAD:
 					for index in _closing_queue:
 						reload_file(index)
-			elif _is_closing_all:
-				close_all()
-			else:
-				for index in _closing_queue:
-					close_file(index)
+				PendingAction.CLOSE_ALL:
+					close_all()
+				PendingAction.CLOSE:
+					for index in _closing_queue:
+						close_file(index)
+				_:
+					printerr("[Sprouty Dialogs] Discard action not implemented for pending action: " + str(_pending_action))
 	_closing_queue.clear()
-	_is_closing_all = false
-	_is_reloading = false
+	_pending_action = PendingAction.NONE
 
 
 ## Cancel the closing confirmation dialog
 func _on_confirm_closing_canceled() -> void:
 	_closing_queue.clear()
-	_is_reloading = false
+	_pending_action = PendingAction.NONE
 
 
 ## Filter the file list by the input search text

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_list_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_list_manager.gd
@@ -20,6 +20,9 @@ signal request_save_file_as(index: int)
 ## Emitted when requesting to reload a file from disk.
 signal request_reload_file(index: int)
 
+## Pending file operation awaiting confirmation in the unsaved-changes dialog
+enum PendingAction { NONE, CLOSE, CLOSE_ALL, RELOAD, RELOAD_ALL }
+
 ## File search input
 @onready var _file_search: LineEdit = $FileSearch
 ## File list on side bar
@@ -40,8 +43,7 @@ var _char_icon := preload("res://addons/sprouty_dialogs/editor/icons/character.s
 var _current_file_index: int = -1
 ## Files to close queue
 var _closing_queue: Array[int] = []
-## Pending file operation awaiting confirmation in the unsaved-changes dialog
-enum PendingAction { NONE, CLOSE, CLOSE_ALL, RELOAD, RELOAD_ALL }
+## Current pending action awaiting user confirmation
 var _pending_action: PendingAction = PendingAction.NONE
 ## Save button of the confirm dialog, hidden when reloading files
 var _confirm_save_button: Button

--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -97,6 +97,7 @@ func _ready() -> void:
 			save_file_dialog.popup_centered()
 			)
 		)
+	_file_list.request_reload_file.connect(reload_file)
 
 	_close_editor_warning.custom_action.connect(_on_confirm_closing_editor_action)
 	_close_editor_warning.canceled.connect(func(): return null)
@@ -296,6 +297,50 @@ func load_file(path: String, check_resources: bool = true, view_state: Dictionar
 			return
 	else:
 		printerr("[Sprouty Dialogs] File " + path + "does not exist.")
+
+
+## Reload a file from disk, discarding any unsaved changes
+func reload_file(index: int) -> void:
+	var file_metadata = _file_list.get_item_metadata(index)
+	var path: String = file_metadata["file_path"]
+
+	if not FileAccess.file_exists(path):
+		printerr("[Sprouty Dialogs] File " + path + " does not exist.")
+		return
+
+	# Load the resource again from disk to discard the cached changes
+	var resource = ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_REPLACE)
+	var view_state: Dictionary = file_metadata["cache_node"].get_editor_state()
+	var cache_node: Node = null
+	var csv_path := ""
+
+	if resource is SproutyDialogsDialogueData:
+		cache_node = _new_graph_from_resource(resource)
+		if SproutyDialogsFileUtils.check_valid_uid_path(resource.csv_file_uid):
+			csv_path = ResourceUID.get_id_path(resource.csv_file_uid)
+	elif resource is SproutyDialogsCharacterData:
+		cache_node = _new_character_from_resource(resource)
+	else:
+		printerr("[Sprouty Dialogs] File " + path + " is not a valid dialogue or character resource.")
+		return
+
+	if not view_state.is_empty():
+		cache_node.load_editor_state(view_state)
+	cache_node.set_meta("file_index", index)
+
+	# Replace the cached editor node and update the file metadata
+	file_metadata["cache_node"].queue_free()
+	file_metadata["cache_node"] = cache_node
+	file_metadata["data"] = resource
+	file_metadata["csv_file"] = csv_path
+	_file_list.set_item_metadata(index, file_metadata)
+	_file_list.set_file_as_modified(index, false)
+
+	# Refresh the editor if the reloaded file is the current one
+	if index == _file_list.get_current_index():
+		switch_to_selected_file(file_metadata)
+
+	print("[Sprouty Dialogs] File '" + file_metadata.file_name + "' reloaded.")
 
 
 ## Save data to resource file

--- a/addons/sprouty_dialogs/l10n/l10n.csv
+++ b/addons/sprouty_dialogs/l10n/l10n.csv
@@ -13,6 +13,8 @@ Save As...,Editor -> Side Bar,Save As...,另存为...
 Save a File,Editor -> Side Bar,Save a File,保存文件
 Close,Editor -> Side Bar,Close,关闭
 Close All,Editor -> Side Bar,Close All,全部关闭
+Reload,Editor -> Side Bar,Reload,重新加载
+Reload All,Editor -> Side Bar,Reload All,全部重新加载
 Emoji & Symbols,Editor -> Side Bar,Emoji & Symbols,表情和符号
 Cut,Editor -> Side Bar,Cut,剪切
 Copy,Editor -> Side Bar,Copy,复制
@@ -223,6 +225,10 @@ Add a repeat tag in the selected text. Repeats the content inside the tag a spec
 Are you sure you want to close this file/s?",Editor -> Dialogue Panel -> Confirmation Dialog,"The file/s contains unsaved changes. 
 Are you sure you want to close this file/s?","文件包含未保存的更改。
 确定要关闭这些文件吗？"
+"The file/s contains unsaved changes.
+Are you sure you want to reload this file/s?",Editor -> Dialogue Panel -> Confirmation Dialog,"The file/s contains unsaved changes.
+Are you sure you want to reload this file/s?","文件包含未保存的更改。
+确定要重新加载这些文件吗？"
 Discard,Editor -> Dialogue Panel -> Confirmation Dialog,Discard,放弃
 "[center][wave]Create or open a [color=orange]character[/color] to start!
 [center]\( ^-^)/

--- a/addons/sprouty_dialogs/l10n/l10n.csv
+++ b/addons/sprouty_dialogs/l10n/l10n.csv
@@ -226,9 +226,9 @@ Are you sure you want to close this file/s?",Editor -> Dialogue Panel -> Confirm
 Are you sure you want to close this file/s?","文件包含未保存的更改。
 确定要关闭这些文件吗？"
 "The file/s contains unsaved changes.
-Are you sure you want to reload this file/s?",Editor -> Dialogue Panel -> Confirmation Dialog,"The file/s contains unsaved changes.
-Are you sure you want to reload this file/s?","文件包含未保存的更改。
-确定要重新加载这些文件吗？"
+Are you sure you want to reload this file/s from disk?",Editor -> Dialogue Panel -> Confirmation Dialog,"The file/s contains unsaved changes.
+Are you sure you want to reload this file/s from disk?","文件包含未保存的更改。
+确定要从磁盘重新加载这些文件吗？"
 Discard,Editor -> Dialogue Panel -> Confirmation Dialog,Discard,放弃
 "[center][wave]Create or open a [color=orange]character[/color] to start!
 [center]\( ^-^)/


### PR DESCRIPTION
Adds "Reload" / "Reload All" items to the file manager context menu, which
re-read a file from disk and discard unsaved changes, with an unsaved-changes
confirmation.

- Reload a single file or all open files (dialogue and character files).
- Reuses the existing unsaved-changes dialog; the reload variant hides the
  Save button and shows a reload-specific prompt.
- Confirmation state is tracked with a single `PendingAction` enum
  (CLOSE / CLOSE_ALL / RELOAD / RELOAD_ALL); the discard path is exhaustive
  and reports an error on any unhandled state.
- Reload prompt text is authored in the scene and translated via the
  sprouty_dialogs translation domain, consistent with the other dialogs
  (added zh_Hans entries).
  
 This is especially useful when working with AI agents that edit dialogue
resources directly on disk: instead of closing and reopening the file (or
restarting the editor) to pick up those external changes, you can just hit
Reload.