### PR TITLE
Save editor state as cache

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
+++ b/addons/sprouty_dialogs/editor/modules/file_manager/scripts/file_manager.gd
@@ -604,7 +604,7 @@ func _on_confirm_closing_editor_action(action) -> void:
 			get_tree().quit()
 
 
-## Save the list of currently opened files to the project settings
+## Save the list of currently opened files to the editor state cache.
 func _save_opened_files() -> void:
 	var opened_files: Array = []
 
@@ -623,14 +623,14 @@ func _save_opened_files() -> void:
 
 	# Save the currently selected file index
 	var current_index = _file_list.get_current_index()
-	SproutyDialogsSettingsManager.set_setting("last_opened_files", opened_files)
-	SproutyDialogsSettingsManager.set_setting("last_selected_file_index", current_index)
+	SproutyDialogsEditorStateManager.set_value("window_state", "last_opened_files", opened_files)
+	SproutyDialogsEditorStateManager.set_value("window_state", "last_selected_file_index", current_index)
 
 
-## Load the list of last opened files from the project settings
+## Load the list of last opened files from the editor state cache.
 func _load_opened_files() -> void:
-	var last_opened_files = SproutyDialogsSettingsManager.get_setting("last_opened_files")
-	var last_selected_index = SproutyDialogsSettingsManager.get_setting("last_selected_file_index")
+	var last_opened_files = SproutyDialogsEditorStateManager.get_value("window_state", "last_opened_files")
+	var last_selected_index = SproutyDialogsEditorStateManager.get_value("window_state", "last_selected_file_index")
 	last_selected_index = last_selected_index if last_selected_index != null else -1
 	
 	if not (last_opened_files is Array and last_opened_files.size() > 0):
@@ -665,6 +665,6 @@ func _on_editor_view_state_changed(view_state: Dictionary) -> void:
 	if file_metadata == null:
 		return
 	if file_metadata.has("cache_node") and file_metadata["cache_node"] != null:
-		var file_list = SproutyDialogsSettingsManager.get_setting("last_opened_files")
+		var file_list = SproutyDialogsEditorStateManager.get_value("window_state", "last_opened_files")
 		file_list[current_index]["view_state"] = view_state
-		SproutyDialogsSettingsManager.set_setting("last_opened_files", file_list)
+		SproutyDialogsEditorStateManager.set_value("window_state", "last_opened_files", file_list)

--- a/addons/sprouty_dialogs/editor/scripts/editor.gd
+++ b/addons/sprouty_dialogs/editor/scripts/editor.gd
@@ -147,7 +147,8 @@ func _setup_update_manager() -> void:
 	_about_panel.set_plugin_version(version)
 
 
-## Play a dialog from the current graph starting from the given ID
+## Save temporary playback state to the editor state cache and play a dialog
+## from the current graph starting from the given ID.
 func play_dialog_scene(start_id: String, dialog_path: String = "") -> void:
 	file_manager.save_file()
 	if dialog_path.is_empty(): # Use the current open dialog
@@ -155,8 +156,8 @@ func play_dialog_scene(start_id: String, dialog_path: String = "") -> void:
 		if dialog_path.is_empty():
 			printerr("[Sprouty Dialogs] Cannot play dialog: No dialog file is open.")
 			return
-	SproutyDialogsSettingsManager.set_setting("play_dialog_path", dialog_path)
-	SproutyDialogsSettingsManager.set_setting("play_start_id", start_id)
+	SproutyDialogsEditorStateManager.set_value("window_state", "play_dialog_path", dialog_path)
+	SproutyDialogsEditorStateManager.set_value("window_state", "play_start_id", start_id)
 	Engine.get_singleton("EditorInterface").play_custom_scene(TEST_SCENE_PATH)
 
 

--- a/addons/sprouty_dialogs/l10n/l10n.csv.import
+++ b/addons/sprouty_dialogs/l10n/l10n.csv.import
@@ -15,3 +15,5 @@ dest_files=["res://addons/sprouty_dialogs/l10n/l10n.en.translation", "res://addo
 
 compress=1
 delimiter=0
+unescape_keys=false
+unescape_translations=true

--- a/addons/sprouty_dialogs/utils/editor_state_manager.gd
+++ b/addons/sprouty_dialogs/utils/editor_state_manager.gd
@@ -66,3 +66,4 @@ static func set_value(section: String, key: String, value: Variant) -> void:
 		return
 
 	_editor_state_file.set_value(section, key, value)
+	_editor_state_file.save("res://.godot/sprouty_dialogs.conf")

--- a/addons/sprouty_dialogs/utils/editor_state_manager.gd
+++ b/addons/sprouty_dialogs/utils/editor_state_manager.gd
@@ -1,0 +1,68 @@
+@tool
+class_name SproutyDialogsEditorStateManager
+extends RefCounted
+
+# -----------------------------------------------------------------------------
+# Sprouty Dialogs State Editor Manager
+# -----------------------------------------------------------------------------
+## This class manages the temporary editor parameters for the Sprouty Dialogs plugin.
+## It provides methods to get and set editor default values.
+# -----------------------------------------------------------------------------
+
+## Temporary editor state parameters.
+## This cache file stores settings which should not be versioned.
+static var _editor_state_file: ConfigFile:
+	get:
+		if _editor_state_file:
+			return _editor_state_file
+
+		var file := ConfigFile.new()
+		const PATH := "res://.godot/sprouty_dialogs.conf"
+
+		if FileAccess.file_exists(PATH):
+			var load_result := file.load(PATH)
+			if load_result == OK:
+				_editor_state_file = file
+				return file
+			else:
+				printerr("[SproutyDialogs] Couldn't load editor state cache file. An error occurred: "
+					+ error_string(load_result))
+				return null
+
+		# Set default values
+		file.set_value("window_state", "play_dialog_path", "")
+		file.set_value("window_state", "play_start_id", "")
+		file.set_value("window_state", "last_opened_files", [])
+		file.set_value("window_state", "last_selected_file_index", -1)
+
+		file.save(PATH)
+		_editor_state_file = file
+		return file
+
+
+## Returns an editor state value from the cache file.
+## If the value section or key are not found, it returns null and prints an error message.
+static func get_value(section: String, key: String) -> Variant:
+	if not _editor_state_file.has_section(section):
+		printerr("[SproutyDialogs] Editor state section '" + section + "' not found.")
+		return null
+	if not _editor_state_file.has_section_key(section, key):
+		printerr("[SproutyDialogs] Editor state key '" + key + "' not found in section '" + section + "'.")
+		return null
+
+	return _editor_state_file.get_value(section, key)
+
+
+## Sets an editor state value in the cache file.
+## If the value section or key are not found, it prints an error message.
+static func set_value(section: String, key: String, value: Variant) -> void:
+	if not _editor_state_file.has_section(section):
+		printerr("[SproutyDialogs] Editor state section '" + section + "' not found."
+			+ "Cannot set value of key '" + key + "' for that section.")
+		return
+	if not _editor_state_file.has_section_key(section, key):
+		printerr("[SproutyDialogs] Editor state key '" + key + "' not found in section '" + section
+			+ "'. Cannot set value.")
+		return
+
+	_editor_state_file.set_value(section, key, value)

--- a/addons/sprouty_dialogs/utils/editor_state_manager.gd
+++ b/addons/sprouty_dialogs/utils/editor_state_manager.gd
@@ -9,6 +9,9 @@ extends RefCounted
 ## It provides methods to get and set editor default values.
 # -----------------------------------------------------------------------------
 
+## Path in which the cache file that stores editor state will be saved.
+const EDITOR_STATE_FILE_PATH := "res//.godot/sprouty_dialogs_cache.cfg"
+
 ## Temporary editor state parameters.
 ## This cache file stores settings which should not be versioned.
 static var _editor_state_file: ConfigFile:
@@ -17,10 +20,9 @@ static var _editor_state_file: ConfigFile:
 			return _editor_state_file
 
 		var file := ConfigFile.new()
-		const PATH := "res://.godot/sprouty_dialogs.conf"
 
-		if FileAccess.file_exists(PATH):
-			var load_result := file.load(PATH)
+		if FileAccess.file_exists(EDITOR_STATE_FILE_PATH):
+			var load_result := file.load(EDITOR_STATE_FILE_PATH)
 			if load_result == OK:
 				_editor_state_file = file
 				return file
@@ -35,7 +37,7 @@ static var _editor_state_file: ConfigFile:
 		file.set_value("window_state", "last_opened_files", [])
 		file.set_value("window_state", "last_selected_file_index", -1)
 
-		file.save(PATH)
+		file.save(EDITOR_STATE_FILE_PATH)
 		_editor_state_file = file
 		return file
 
@@ -66,4 +68,4 @@ static func set_value(section: String, key: String, value: Variant) -> void:
 		return
 
 	_editor_state_file.set_value(section, key, value)
-	_editor_state_file.save("res://.godot/sprouty_dialogs.conf")
+	_editor_state_file.save(EDITOR_STATE_FILE_PATH)

--- a/addons/sprouty_dialogs/utils/editor_state_manager.gd.uid
+++ b/addons/sprouty_dialogs/utils/editor_state_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://ckhcr57u10wus

--- a/addons/sprouty_dialogs/utils/settings_manager.gd
+++ b/addons/sprouty_dialogs/utils/settings_manager.gd
@@ -150,22 +150,6 @@ static var _settings_paths: Dictionary = {
 		"path": "sprouty_dialogs/internal/variables",
 		"default": {}
 	},
-	"play_dialog_path": {
-		"path": "sprouty_dialogs/internal/play_dialog_path",
-		"default": ""
-	},
-	"play_start_id": {
-		"path": "sprouty_dialogs/internal/play_start_id",
-		"default": ""
-	},
-	"last_opened_files": {
-		"path": "sprouty_dialogs/internal/last_opened_files",
-		"default": []
-	},
-	"last_selected_file_index": {
-		"path": "sprouty_dialogs/internal/last_selected_file_index",
-		"default": - 1
-	}
 }
 
 

--- a/addons/sprouty_dialogs/utils/test_scene/dialog_test_scene.gd
+++ b/addons/sprouty_dialogs/utils/test_scene/dialog_test_scene.gd
@@ -9,8 +9,8 @@ extends Control
 
 func _ready() -> void:
 	var autoload = get_node("/root/SproutyDialogs")
-	var dialog_path = SproutyDialogsSettingsManager.get_setting("play_dialog_path")
-	var start_id = SproutyDialogsSettingsManager.get_setting("play_start_id")
+	var dialog_path = SproutyDialogsEditorStateManager.get_value("window_state", "play_dialog_path")
+	var start_id = SproutyDialogsEditorStateManager.get_value("window_state", "play_start_id")
 
 	print("[Sprouty Dialogs] Playing dialog test scene...")
 	autoload.start_dialog(load(dialog_path), start_id)


### PR DESCRIPTION
Replace editor state settings in Settings Manager class with values in a new Editor State Manager class (closes #124)