### PR TITLE
Fix errors after options node duplication

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
@@ -364,9 +364,7 @@ func get_graph_data() -> Dictionary:
 			
 			# Get option dialogs from options nodes
 			if child.node_type == "options_node":
-				var options = child.get_options_text()
-				for option in options:
-					dict.dialogs.merge(option)
+				dict.dialogs.merge(child.get_options_text())
 			
 			# Start nodes define dialogs trees
 			if child.node_type == "start_node":
@@ -626,7 +624,6 @@ func _copy_node(node: GraphNode) -> GraphNode:
 		false # Do not add to count here, it will be added later
 	)
 	new_node.set_data(node.get_data()[node.name.to_snake_case()])
-	remove_child(new_node)
 
 	_copied_connections[new_node.name] = get_node_connections(node.name)
 	_copied_nodes[new_node.name] = node # Store the copied node reference
@@ -640,6 +637,7 @@ func _copy_node(node: GraphNode) -> GraphNode:
 		"options_node":
 			new_node.load_options_text(node.get_options_text())
 	
+	remove_child(new_node)
 	return new_node
 
 

--- a/addons/sprouty_dialogs/event_nodes/scripts/options_node.gd
+++ b/addons/sprouty_dialogs/event_nodes/scripts/options_node.gd
@@ -73,13 +73,11 @@ func set_data(dict: Dictionary) -> void:
 
 
 ## Returns options text and its translations
-func get_options_text() -> Array:
-	var options_text = []
+func get_options_text() -> Dictionary:
+	var options_text = {}
 	for child in get_children():
 		if child is EditorSproutyDialogsOptionContainer:
-			options_text.append({
-				child.get_dialog_key(): child.get_dialogs_text()
-			})
+			options_text[child.get_dialog_key()] = child.get_dialogs_text().duplicate()
 	return options_text
 
 


### PR DESCRIPTION
Duplicating or copying the `Options Node` triggers the following error stack trace:

```
  ERROR: res://addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd:641 - Invalid type in function 'load_options_text' in base 'GraphNode (options_node.gd)'. Cannot convert argument 1 from Array to Dictionary.
  ERROR: res://addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd:656 - Invalid assignment of property or key 'node_index' with value of type 'int' on a base object of type 'Nil'.
```

So I updated the `get_options_text` function's return type from `Array` to `Dictionary`. Also I moved `remove_child` in copy_node function, because `Options Node` generate elements in the tree during data load.