### PR TITLE
Fix the disconnection of nodes with multiple inputs

### DIFF
--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
@@ -936,7 +936,7 @@ func disconnect_node_on_port(node: String, port: int, as_action: bool = false) -
 		if data["has_other_input"]:
 			if data["remaining_start_node"] != next_node.start_node:
 				next_node.start_node = data["remaining_start_node"]
-				_update_connections_start_node(next_node)
+			_update_connections_start_node(next_node)
 		elif data["same_start_node"]:
 			next_node.start_node = null
 			_update_connections_start_node(next_node)
@@ -1093,16 +1093,41 @@ func _on_connection_request(from_node: String, from_port: int, to_node: String, 
 	# --------------------------------------------------------------------------
 
 
+## Follow incoming connections backwards to find the actual start node for this branch.
+func _find_start_node_from_inputs(node: SproutyDialogsBaseNode, visited: Dictionary = {}) -> SproutyDialogsBaseNode:
+	if node == null or visited.has(node.name):
+		return null
+	visited[node.name] = true
+	
+	if node.node_type == "start_node":
+		return node
+	
+	for connection in get_node_connections(node.name, false, false):
+		var prev_node = get_node_or_null(NodePath(connection["from_node"]))
+		if prev_node == null:
+			continue
+		var start_node = _find_start_node_from_inputs(prev_node, visited)
+		if start_node != null:
+			return start_node
+	
+	return null
+
+
 ## Update connected nodes with the new start node
 func _update_connections_start_node(node: SproutyDialogsBaseNode, visited: Dictionary = {}) -> void:
-	if visited.has(node.name):
+	if node == null or visited.has(node.name):
 		return
 	visited[node.name] = true
+	
+	if node.node_type == "start_node":
+		node.start_node = node
+	else:
+		node.start_node = _find_start_node_from_inputs(node, {})
+	
 	var connections = node.get_output_connections()
 	for node_name in connections:
 		var next_node = get_node_or_null(node_name)
 		if next_node != null and not visited.has(next_node.name):
-			next_node.start_node = node.start_node
 			_update_connections_start_node(next_node, visited)
 
 

--- a/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
+++ b/addons/sprouty_dialogs/editor/modules/graph_editor/scripts/graph_editor.gd
@@ -894,6 +894,18 @@ func disconnect_node_on_port(node: String, port: int, as_action: bool = false) -
 	for connection in port_connections:
 		var next_node = get_node_or_null(NodePath(connection["to_node"]))
 		var from_node = get_node(NodePath(connection["from_node"]))
+		var remaining_input_node: SproutyDialogsBaseNode = null
+		var remaining_start_node = null
+		
+		if next_node != null:
+			var input_connections = get_node_connections(connection["to_node"], false, false)
+			for input_connection in input_connections:
+				if input_connection["from_node"] == connection["from_node"] and input_connection["from_port"] == connection["from_port"]:
+					continue
+				remaining_input_node = get_node_or_null(NodePath(input_connection["from_node"]))
+				if remaining_input_node != null:
+					remaining_start_node = remaining_input_node.start_node
+					break
 		
 		connection_data[connection["to_node"]] = {
 			"next_node": next_node,
@@ -901,7 +913,10 @@ func disconnect_node_on_port(node: String, port: int, as_action: bool = false) -
 			"prev_next_start_node": next_node.start_node if next_node != null else null,
 			"prev_from_to_dialog": from_node.to_dialog if from_node != null else "",
 			"next_start_id": next_node.get_start_id() if next_node != null else "",
-			"same_start_node": (next_node != null and from_node != null and next_node.start_node == from_node.start_node)
+			"same_start_node": (next_node != null and from_node != null and next_node.start_node == from_node.start_node),
+			"remaining_input_node": remaining_input_node,
+			"remaining_start_node": remaining_start_node,
+			"has_other_input": remaining_input_node != null
 		}
 
 	# Disconnect all connections from the port
@@ -912,12 +927,21 @@ func disconnect_node_on_port(node: String, port: int, as_action: bool = false) -
 		var next_node = data["next_node"]
 		var from_node = data["from_node"]
 		
-		# If the disconnected node has the same start node, remove the reference
-		if data["same_start_node"]:
+		if next_node == null:
+			continue
+		
+		# If another input remains, keep the same start node if it belongs to the same dialog tree,
+		# otherwise rebind it to the remaining input's start node. If there is no other input and
+		# this disconnected connection was the one owning the same start node, clear it.
+		if data["has_other_input"]:
+			if data["remaining_start_node"] != next_node.start_node:
+				next_node.start_node = data["remaining_start_node"]
+				_update_connections_start_node(next_node)
+		elif data["same_start_node"]:
 			next_node.start_node = null
 			_update_connections_start_node(next_node)
 		# If the disconnected node belongs to other dialog tree, remove the reference to the dialog tree
-		elif next_node != null and from_node.to_dialog == data["next_start_id"]:
+		elif from_node != null and from_node.to_dialog == data["next_start_id"]:
 			from_node.to_dialog = ""
 	
 	if not as_action:
@@ -939,14 +963,20 @@ func disconnect_node_on_port(node: String, port: int, as_action: bool = false) -
 		undo_redo.add_undo_method(self, "connect_node", connection["from_node"],
 			connection["from_port"], connection["to_node"], connection["to_port"])
 		
-		# If the disconnected node has the same start node, update the start node reference
-		if data["same_start_node"]:
-			undo_redo.add_do_property(next_node, "start_node", null)
-			undo_redo.add_undo_property(next_node, "start_node", data["prev_next_start_node"])
-			undo_redo.add_do_method(self, "_update_connections_start_node", next_node)
-			undo_redo.add_undo_method(self, "_update_connections_start_node", next_node)
+		if next_node != null:
+			if data["has_other_input"]:
+				if data["remaining_start_node"] != data["prev_next_start_node"]:
+					undo_redo.add_do_property(next_node, "start_node", data["remaining_start_node"])
+					undo_redo.add_undo_property(next_node, "start_node", data["prev_next_start_node"])
+					undo_redo.add_do_method(self, "_update_connections_start_node", next_node)
+					undo_redo.add_undo_method(self, "_update_connections_start_node", next_node)
+			elif data["same_start_node"]:
+				undo_redo.add_do_property(next_node, "start_node", null)
+				undo_redo.add_undo_property(next_node, "start_node", data["prev_next_start_node"])
+				undo_redo.add_do_method(self, "_update_connections_start_node", next_node)
+				undo_redo.add_undo_method(self, "_update_connections_start_node", next_node)
 		# If the disconnected node belongs to other dialog tree, update the reference to the dialog tree
-		elif next_node != null and from_node.to_dialog == data["next_start_id"]:
+		elif from_node != null and from_node.to_dialog == data["next_start_id"]:
 			undo_redo.add_do_property(from_node, "to_dialog", "")
 			undo_redo.add_undo_property(from_node, "to_dialog", data["prev_from_to_dialog"])
 	


### PR DESCRIPTION
The nodes disconnection logic has been fixed. Now when a node is disconnected from a node with multiple inputs, the start node reference is updated correctly to the start node of one of the remains inputs, instead of clear it and categorize incorrectly as an unplugged node.

- Closes #131 