### PR TITLE
Add dialog box overrides in DialogPlayer

### DIFF
--- a/addons/sprouty_dialogs/nodes/dialog_player.gd
+++ b/addons/sprouty_dialogs/nodes/dialog_player.gd
@@ -114,20 +114,39 @@ var print_debug: bool = false
 
 #region === Display Overrides ==================================================
 
-## [Node] to override the default portraits display parent node.[br][br]
-## This is used if you want to display portraits in some scene node
-## instead of the default canvas layer to portraits (override parent node).[br][br]
-## [i]You can also set the parent node for each character individually below.
+## [Node] to override the default portraits display parent node.
+##
+## [br][br]This is used if you want to display portraits in some scene node
+## instead of the default canvas layer to portraits (override parent node).
+## 
+## [br][br][i]You can also set the parent node for each character individually below.
 var _portraits_display_override: Node = null
-## [Node] to override the default dialog box display parent node.[br][br]
-## This is used if you want to display dialog boxes in some scene node
-## instead of the default canvas layer to dialog boxes (override parent node).[br][br]
-## [i]You can also set the parent node for each character individually below.
+## [Node] to override the default dialog box display parent node.
+## 
+## [br][br]This is used if you want to display dialog boxes in some scene node
+## instead of the default canvas layer to dialog boxes (override parent node).
+## 
+## [br][br][i]You can also set the parent node for each character individually below.
 var _dialog_box_display_override: Node = null
-## [DialogBox] to override the default dialog box node used to display the dialog.[br][br]
-## This is used if you want to use a custom dialog box node instead of the default one.[br][br]
-## [i]You can also set the dialog box node for each character individually below.
+## [DialogBox] to override the default dialog box node used to display the dialog.
+##
+## [br][br]This is used if you want to use a custom dialog box node instead of the default one.[br]
+## You can change the default dialog box in [b]Sprouty Dialogs Tab > Settings > Defaults[/b].
+## 
+## [br][br][i]You can also set the dialog box node for each character individually below.
+## [br][br]Note: If you set a dialog box override for a character, it will override the 
+## dialog box assigned in the character data resource for that character.
 var _dialog_box_override: DialogBox = null
+## If [code]true[/code], the [DialogPlayer] will ignore the display override 
+## parent node for the overridden dialog box node.
+## 
+## [br][br]This is used if you want to use a custom dialog box node that is already
+## placed in the scene tree and you don't want to change its parent node.
+## 
+## [br][br][i]You can also set the ignore display override flag for each character individually below.
+## [br][br][i]Note: This only applies to the [member _dialog_box_override] node, 
+## not the default dialog box, or the dialog boxes overridden for each character.
+var _ignore_dialog_box_display_override: bool = false
 ## Dictionary to store the portrait display parent nodes by character.
 ## This is used if you want to display dialog boxes in some scene node
 ## instead of the default canvas layer to dialog boxes (override parent node).
@@ -156,12 +175,17 @@ var _portraits_display_per_character: Dictionary = {}
 var _dialog_box_display_per_character: Dictionary = {}
 ## Dictionary to store the dialog box override nodes by character.
 ## This is used if you want to use a custom dialog box node instead of the default one.
-## The keys are character names and the values are the dialog box nodes to use.
-## The dictionary structure is:
+## The keys are character names and the values follow the following structure:
 ## [codeblock]
 ## {
-##   "character_name_1": DialogBox instance,
-##   "character_name_2": DialogBox instance,
+##   "character_name_1": {
+##	    "dialog_box": DialogBox instance,
+##		"ignore_display_override": bool,
+##	},
+##   "character_name_2": {
+##	    "dialog_box": DialogBox instance,
+##		"ignore_display_override": bool,
+##	},
 ##   ...
 ## }[/codeblock]
 var _dialog_box_override_per_character: Dictionary = {}
@@ -313,6 +337,11 @@ func _get_property_list():
 				"hint": PROPERTY_HINT_NODE_TYPE,
 				"hint_string": "DialogBox",
 			})
+			props.append({ # Set dialog box ignore display override flag (general)
+				"name": &"_ignore_dialog_box_display_override",
+				"type": TYPE_BOOL,
+				"usage": PROPERTY_USAGE_DEFAULT
+			})
 			if not _start_id.is_empty() and _start_id in _dialog_data.characters:
 				for char in _dialog_data.characters[_start_id]:
 					props.append({ # Set a group by character name
@@ -327,6 +356,11 @@ func _get_property_list():
 						"usage": PROPERTY_USAGE_DEFAULT,
 						"hint": PROPERTY_HINT_NODE_TYPE,
 						"hint_string": "DialogBox",
+					})
+					props.append({ # Set ignore override flag by character
+						"name": char + "_ignore_display_override",
+						"type": TYPE_BOOL,
+						"usage": PROPERTY_USAGE_DEFAULT
 					})
 			# Display overrides group ------------------------------------------
 			props.append({
@@ -389,7 +423,13 @@ func _get(property: StringName):
 	# Show the dialog box node path by character
 	if property.ends_with("_dialog_box_override"):
 		var char_name = property.get_slice("_dialog_box_", 0)
-		return _dialog_box_override_per_character[char_name]
+		return _dialog_box_override_per_character[char_name]["dialog_box"]
+	
+	# Show the ignore parent override flag by character
+	if property.ends_with("_ignore_display_override"):
+		var char_name = property.get_slice("_ignore_display_override", 0)
+		return _dialog_box_override_per_character[char_name]["ignore_display_override"]
+
 	return null
 
 
@@ -411,7 +451,13 @@ func _set(property: StringName, value: Variant) -> bool:
 	# Storing the dialog box node path by character
 	if property.ends_with("_dialog_box_override"):
 		var char_name = property.get_slice("_dialog_box_", 0)
-		_dialog_box_override_per_character[char_name] = value
+		_dialog_box_override_per_character[char_name]["dialog_box"] = value
+		return true
+
+	# Storing the ignore parent override flag by character
+	if property.ends_with("_ignore_display_override"):
+		var char_name = property.get_slice("_ignore_display_override", 0)
+		_dialog_box_override_per_character[char_name]["ignore_display_override"] = value
 		return true
 	return false
 
@@ -566,7 +612,7 @@ func get_dialog_box_override(character_name: String = "") -> DialogBox:
 	if character_name == "":
 		return _dialog_box_override
 	if _dialog_box_override_per_character.has(character_name):
-		return _dialog_box_override_per_character[character_name]
+		return _dialog_box_override_per_character[character_name]["dialog_box"]
 	return null
 
 
@@ -593,11 +639,19 @@ func set_dialog_box_display_override(dialog_box_parent: Node, character_name: St
 ## Set the dialog box node to be used for a given character.
 ## If no character name is provided, it sets the default overrided dialog box
 ## node for all characters (If is set, otherwise it returns null).
-func set_dialog_box_override(dialog_box: DialogBox, character_name: String = "") -> void:
+## [br][br]If the [code]ignore_display_override[/code] flag is set to [code]true[/code], 
+## the dialog box will be used as is, without changing its parent node.
+func set_dialog_box_override(
+		dialog_box: DialogBox,
+		ignore_display_override: bool = false,
+		character_name: String = "",
+	) -> void:
 	if character_name == "":
 		_dialog_box_override = dialog_box
+		_ignore_dialog_box_display_override = ignore_display_override
 	else:
-		_dialog_box_override_per_character[character_name] = dialog_box
+		_dialog_box_override_per_character[character_name]["dialog_box"] = dialog_box
+		_dialog_box_override_per_character[character_name]["ignore_display_override"] = ignore_display_override
 
 
 ## Set the dialogue data and start ID to play a dialog tree.
@@ -635,7 +689,10 @@ func _set_overrides_dictionaries() -> void:
 	for char in _dialog_data.characters[_start_id]:
 		_portraits_display_per_character[char] = null
 		_dialog_box_display_per_character[char] = null
-		_dialog_box_override_per_character[char] = null
+		_dialog_box_override_per_character[char] = {
+			"dialog_box": null,
+			"ignore_display_override": false
+		}
 
 
 ## Returns the name of the start node for a given dialog branch.
@@ -955,6 +1012,7 @@ func _update_dialog_box(character_name: String) -> void:
 		# Instantiate the dialog box if it is not already loaded
 		dialog_box = _resource_manager.instantiate_dialog_box(
 			character_name, display_parent, _dialog_box_override,
+			_ignore_dialog_box_display_override,
 			_dialog_box_override_per_character[character_name]
 			)
 		dialog_box.set_auto_advance(auto_advance)

--- a/addons/sprouty_dialogs/nodes/dialog_player.gd
+++ b/addons/sprouty_dialogs/nodes/dialog_player.gd
@@ -143,9 +143,9 @@ var _dialog_box_override: DialogBox = null
 ## [br][br]This is used if you want to use a custom dialog box node that is already
 ## placed in the scene tree and you don't want to change its parent node.
 ## 
-## [br][br][i]You can also set the ignore display override flag for each character individually below.
 ## [br][br][i]Note: This only applies to the [member _dialog_box_override] node, 
 ## not the default dialog box, or the dialog boxes overridden for each character.
+## [br][br][i]You can set the ignore display override flag for each character individually below.
 var _ignore_dialog_box_display_override: bool = false
 ## Dictionary to store the portrait display parent nodes by character.
 ## This is used if you want to display dialog boxes in some scene node

--- a/addons/sprouty_dialogs/nodes/dialog_player.gd
+++ b/addons/sprouty_dialogs/nodes/dialog_player.gd
@@ -58,10 +58,7 @@ var _dialog_data: SproutyDialogsDialogueData:
 var _start_id: String:
 	set(value):
 		_start_id = value
-		if _dialog_data and _dialog_data.characters.has(value):
-			for char in _dialog_data.characters[value]:
-				_portraits_display_per_character[char] = null
-				_dialog_box_display_per_character[char] = null
+		_set_overrides_dictionaries()
 		if Engine.is_editor_hint():
 			notify_property_list_changed()
 			update_configuration_warnings()
@@ -127,6 +124,10 @@ var _portraits_display_override: Node = null
 ## instead of the default canvas layer to dialog boxes (override parent node).[br][br]
 ## [i]You can also set the parent node for each character individually below.
 var _dialog_box_display_override: Node = null
+## [DialogBox] to override the default dialog box node used to display the dialog.[br][br]
+## This is used if you want to use a custom dialog box node instead of the default one.[br][br]
+## [i]You can also set the dialog box node for each character individually below.
+var _dialog_box_override: DialogBox = null
 ## Dictionary to store the portrait display parent nodes by character.
 ## This is used if you want to display dialog boxes in some scene node
 ## instead of the default canvas layer to dialog boxes (override parent node).
@@ -153,6 +154,17 @@ var _portraits_display_per_character: Dictionary = {}
 ##   ...
 ## }[/codeblock]
 var _dialog_box_display_per_character: Dictionary = {}
+## Dictionary to store the dialog box override nodes by character.
+## This is used if you want to use a custom dialog box node instead of the default one.
+## The keys are character names and the values are the dialog box nodes to use.
+## The dictionary structure is:
+## [codeblock]
+## {
+##   "character_name_1": DialogBox instance,
+##   "character_name_2": DialogBox instance,
+##   ...
+## }[/codeblock]
+var _dialog_box_override_per_character: Dictionary = {}
 
 #region === Internal Variables =================================================
 
@@ -269,7 +281,7 @@ func _get_property_list():
 			})
 			# Advanced settings group ------------------------------------------
 			props.append({
-				"name": "Advanced Settings",
+				"name": "Auto Advance Settings",
 				"type": TYPE_STRING,
 				"usage": PROPERTY_USAGE_GROUP
 			})
@@ -288,27 +300,55 @@ func _get_property_list():
 				"type": TYPE_BOOL,
 				"usage": PROPERTY_USAGE_DEFAULT
 			})
-			# Characters options by dialog -------------------------------------
+			# Dialog box overrides group ---------------------------------------
+			props.append({
+			"name": "Dialog Box Overrides",
+			"type": TYPE_STRING,
+			"usage": PROPERTY_USAGE_GROUP,
+			})
+			props.append({ # Set custom dialog box (general)
+				"name": &"_dialog_box_override",
+				"type": TYPE_OBJECT,
+				"usage": PROPERTY_USAGE_DEFAULT,
+				"hint": PROPERTY_HINT_NODE_TYPE,
+				"hint_string": "DialogBox",
+			})
 			if not _start_id.is_empty() and _start_id in _dialog_data.characters:
-				props.append({
-				"name": "Display Overrides",
-				"type": TYPE_STRING,
-				"usage": PROPERTY_USAGE_GROUP,
-				})
-				props.append({ # Set portrait display parent node (general)
-					"name": &"_portraits_display_override",
-					"type": TYPE_OBJECT,
-					"usage": PROPERTY_USAGE_DEFAULT,
-					"hint": PROPERTY_HINT_NODE_TYPE,
-					"hint_string": "Node",
-				})
-				props.append({ # Set dialogue box display parent node (general)
-					"name": &"_dialog_box_display_override",
-					"type": TYPE_OBJECT,
-					"usage": PROPERTY_USAGE_DEFAULT,
-					"hint": PROPERTY_HINT_NODE_TYPE,
-					"hint_string": "Node",
-				})
+				for char in _dialog_data.characters[_start_id]:
+					props.append({ # Set a group by character name
+						"name": char.capitalize(),
+						"type": TYPE_STRING,
+						"usage": PROPERTY_USAGE_SUBGROUP,
+						"hint_string": char,
+					})
+					props.append({ # Set dialog box node path by character
+						"name": char + "_dialog_box_override",
+						"type": TYPE_OBJECT,
+						"usage": PROPERTY_USAGE_DEFAULT,
+						"hint": PROPERTY_HINT_NODE_TYPE,
+						"hint_string": "DialogBox",
+					})
+			# Display overrides group ------------------------------------------
+			props.append({
+			"name": "Display Overrides",
+			"type": TYPE_STRING,
+			"usage": PROPERTY_USAGE_GROUP,
+			})
+			props.append({ # Set portrait display parent node (general)
+				"name": &"_portraits_display_override",
+				"type": TYPE_OBJECT,
+				"usage": PROPERTY_USAGE_DEFAULT,
+				"hint": PROPERTY_HINT_NODE_TYPE,
+				"hint_string": "Node",
+			})
+			props.append({ # Set dialog box display parent node (general)
+				"name": &"_dialog_box_display_override",
+				"type": TYPE_OBJECT,
+				"usage": PROPERTY_USAGE_DEFAULT,
+				"hint": PROPERTY_HINT_NODE_TYPE,
+				"hint_string": "Node",
+			})
+			if not _start_id.is_empty() and _start_id in _dialog_data.characters:
 				for char in _dialog_data.characters[_start_id]:
 					props.append({ # Set a group by character name
 						"name": char.capitalize(),
@@ -323,7 +363,7 @@ func _get_property_list():
 						"hint": PROPERTY_HINT_NODE_TYPE,
 						"hint_string": "Node",
 					})
-					props.append({ # Set dialogue box node path by character
+					props.append({ # Set dialog box parent node path by character
 						"name": char + "_dialog_box_display",
 						"type": TYPE_OBJECT,
 						"usage": PROPERTY_USAGE_DEFAULT,
@@ -340,11 +380,16 @@ func _get(property: StringName):
 		var char_name = property.get_slice("_portraits_", 0)
 		return _portraits_display_per_character[char_name]
 
-	# Show the dialogue box node path by character
+	# Show the dialog box parent node path by character
 	if property.ends_with("_dialog_box_display") \
 			or property.ends_with("_dialog_box_parent"):
 		var char_name = property.get_slice("_dialog_", 0)
 		return _dialog_box_display_per_character[char_name]
+	
+	# Show the dialog box node path by character
+	if property.ends_with("_dialog_box_override"):
+		var char_name = property.get_slice("_dialog_box_", 0)
+		return _dialog_box_override_per_character[char_name]
 	return null
 
 
@@ -356,11 +401,17 @@ func _set(property: StringName, value: Variant) -> bool:
 		_portraits_display_per_character[char_name] = value
 		return true
 	
-	# Storing the dialogue box node path by character
+	# Storing the dialog box parent node path by character
 	if property.ends_with("_dialog_box_display") \
 			or property.ends_with("_dialog_box_parent"):
 		var char_name = property.get_slice("_dialog_", 0)
 		_dialog_box_display_per_character[char_name] = value
+		return true
+
+	# Storing the dialog box node path by character
+	if property.ends_with("_dialog_box_override"):
+		var char_name = property.get_slice("_dialog_box_", 0)
+		_dialog_box_override_per_character[char_name] = value
 		return true
 	return false
 
@@ -508,6 +559,17 @@ func get_dialog_box_display_override(character_name: String = "") -> Node:
 	return null
 
 
+## Returns the dialog box node to be used for a given character.
+## If no character name is provided, it returns the default overrided dialog box
+## node for all characters (If is set, otherwise it returns null).
+func get_dialog_box_override(character_name: String = "") -> DialogBox:
+	if character_name == "":
+		return _dialog_box_override
+	if _dialog_box_override_per_character.has(character_name):
+		return _dialog_box_override_per_character[character_name]
+	return null
+
+
 ## Set the parent node where the portraits will be displayed for a given character.
 ## If no character name is provided, it sets the default overrided parent node
 ## for all characters (If is set, otherwise it returns null).
@@ -526,6 +588,16 @@ func set_dialog_box_display_override(dialog_box_parent: Node, character_name: St
 		_dialog_box_display_override = dialog_box_parent
 	else:
 		_dialog_box_display_per_character[character_name] = dialog_box_parent
+
+
+## Set the dialog box node to be used for a given character.
+## If no character name is provided, it sets the default overrided dialog box
+## node for all characters (If is set, otherwise it returns null).
+func set_dialog_box_override(dialog_box: DialogBox, character_name: String = "") -> void:
+	if character_name == "":
+		_dialog_box_override = dialog_box
+	else:
+		_dialog_box_override_per_character[character_name] = dialog_box
 
 
 ## Set the dialogue data and start ID to play a dialog tree.
@@ -554,6 +626,16 @@ func set_dialog(data: SproutyDialogsDialogueData, start_id: String,
 	
 	# Load the resources
 	_load_dialog_resources(_start_id)
+
+
+## Set the override dictionaries for portraits and dialog boxes per character.
+func _set_overrides_dictionaries() -> void:
+	if not _dialog_data or not _starts_ids.has(_start_id):
+		return
+	for char in _dialog_data.characters[_start_id]:
+		_portraits_display_per_character[char] = null
+		_dialog_box_display_per_character[char] = null
+		_dialog_box_override_per_character[char] = null
 
 
 ## Returns the name of the start node for a given dialog branch.
@@ -862,13 +944,19 @@ func _on_continue_dialog() -> void:
 func _update_dialog_box(character_name: String) -> void:
 	var dialog_box = null
 
-	# Check if the dialog box is already loaded
+	# If the character already has a dialog box instance, use it
 	if _dialog_box_instances.has(character_name):
 		dialog_box = _dialog_box_instances[character_name]
-	else: # If the dialog box is not loaded, instantiate it
+	else:
+		# If the character has a display parent override, use it
 		var display_parent = _dialog_box_display_per_character.get(character_name, null)
 		if not display_parent: display_parent = _dialog_box_display_override
-		dialog_box = _resource_manager.instantiate_dialog_box(character_name, display_parent)
+
+		# Instantiate the dialog box if it is not already loaded
+		dialog_box = _resource_manager.instantiate_dialog_box(
+			character_name, display_parent, _dialog_box_override,
+			_dialog_box_override_per_character[character_name]
+			)
 		dialog_box.set_auto_advance(auto_advance)
 		dialog_box.text_reveal_skippable = text_reveal_skippable
 		_dialog_box_instances[character_name] = dialog_box

--- a/addons/sprouty_dialogs/utils/resource_manager.gd
+++ b/addons/sprouty_dialogs/utils/resource_manager.gd
@@ -261,30 +261,51 @@ func _load_portraits(character_name: String, portrait_names: Array) -> void:
 #region === Instantiate Resources ==============================================
 
 ## Instantiate a dialog box for a character in the scene.
-## Instantiate from the loaded dialog boxes for the dialogs in the current scene.
+## This will instantiate the dialog box scene for the character and add it to 
+## the specified parent node.
+##
+## If the character has a dialog box override, it will be used instead of the 
+## default dialog box. Otherwise, the default dialog box will be instantiated
+## from the loaded dialog boxes for the dialogs in the current scene.
+##
 ## Cannot instantiate a dialog box that was not previously loaded.
-func instantiate_dialog_box(character_name: String, dialog_box_parent: Node) -> DialogBox:
-	var dialog_box_uid = ""
-	if not character_name.is_empty():
-		dialog_box_uid = _characters_data[character_name].dialog_box_uid
-	
-	# If no character or the character has no dialog box, use the default dialog box
-	if character_name.is_empty() or not SproutyDialogsFileUtils.check_valid_uid_path(dialog_box_uid):
-		dialog_box_uid = SproutyDialogsSettingsManager.get_setting("default_dialog_box")
+func instantiate_dialog_box(
+		character_name: String,
+		dialog_box_parent: Node = null,
+		dialog_box_override: DialogBox = null,
+		dialog_box_char_override: DialogBox = null,
+	) -> DialogBox:
+	var dialog_box = dialog_box_char_override
+	if not dialog_box:
+		# If there is no override for the character, instantiate it from the character data
+		var dialog_box_uid = ""
+		if not character_name.is_empty():
+			dialog_box_uid = _characters_data[character_name].dialog_box_uid
+		
+		# If no character or the character has no dialog box, use the default override or dialog box from settings
+		if character_name.is_empty() or not SproutyDialogsFileUtils.check_valid_uid_path(dialog_box_uid):
+			if dialog_box_override:
+				# If there is a dialog box default override, use it
+				dialog_box = dialog_box_override
+			else: # If no override, use the default dialog box from settings
+				dialog_box_uid = SproutyDialogsSettingsManager.get_setting("default_dialog_box")
 
-	var dialog_box_path = ResourceUID.get_id_path(dialog_box_uid)
-	
-	if not _dialog_boxes.has(dialog_box_path):
-		printerr("[Sprouty Dialogs] Cannot instantiate dialog box. No dialog box" \
-				+ " scene is loaded for the character " + character_name \
-				+ ". Check if the character is in a dialog of the current scene.")
-		return null
-	var dialog_box = _dialog_boxes[dialog_box_path].instantiate()
+		if not dialog_box: # If no dialog box yet, instantiate it from the loaded dialog boxes
+			var dialog_box_path = ResourceUID.get_id_path(dialog_box_uid)
+			
+			if not _dialog_boxes.has(dialog_box_path):
+				printerr("[Sprouty Dialogs] Cannot instantiate dialog box. No dialog box" \
+						+ " scene is loaded for the character " + character_name \
+						+ ". Check if the character is in a dialog of the current scene.")
+				return null
+			dialog_box = _dialog_boxes[dialog_box_path].instantiate()
 
-	if dialog_box_parent: # Add the dialog box to the specified parent
+	if not dialog_box.get_parent():
+		if dialog_box_parent:
+			# Add the dialog box to the specified parent
 			dialog_box_parent.add_child(dialog_box)
-	else: # If not, add the dialog box to the default canvas
-		_dialog_boxes_canvas.add_child(dialog_box)
+		else: # If not, add the dialog box to the default canvas
+			_dialog_boxes_canvas.add_child(dialog_box)
 
 	return dialog_box
 

--- a/addons/sprouty_dialogs/utils/resource_manager.gd
+++ b/addons/sprouty_dialogs/utils/resource_manager.gd
@@ -310,18 +310,15 @@ func instantiate_dialog_box(
 
 	if dialog_box_parent:
 		# If there is a parent override, and no ignore display override, add it to the parent
-		if using_default_override and not ignore_display_override:
-			if dialog_box.get_parent():
-				dialog_box.get_parent().remove_child(dialog_box)
-			dialog_box_parent.add_child(dialog_box)
-		if not using_default_override and not dialog_box_char_override["ignore_display_override"]:
+		if using_default_override and not ignore_display_override \
+			or not using_default_override and not dialog_box_char_override["ignore_display_override"]:
 			if dialog_box.get_parent():
 				dialog_box.get_parent().remove_child(dialog_box)
 			dialog_box_parent.add_child(dialog_box)
 		# If does not have a parent, but there is a parent override, add to it
 		elif not dialog_box.get_parent():
 			dialog_box_parent.add_child(dialog_box)
-	# If there is no parent override, add it to the default canvas 
+	# If there is no parent or parent override, add it to the default canvas 
 	elif not dialog_box.get_parent(): # (If does not have a parent yet)
 		_dialog_boxes_canvas.add_child(dialog_box)
 

--- a/addons/sprouty_dialogs/utils/resource_manager.gd
+++ b/addons/sprouty_dialogs/utils/resource_manager.gd
@@ -265,17 +265,24 @@ func _load_portraits(character_name: String, portrait_names: Array) -> void:
 ## the specified parent node.
 ##
 ## If the character has a dialog box override, it will be used instead of the 
-## default dialog box. Otherwise, the default dialog box will be instantiated
-## from the loaded dialog boxes for the dialogs in the current scene.
+## setted in the character data resource. Otherwise, the dialog box will be 
+## instantiated from the loaded dialog boxes for the dialogs in the current scene,
+## in case the character has a dialog box set in the character data resource.
+## In other case, the default override or the default dialog box from settings will be used.
 ##
 ## Cannot instantiate a dialog box that was not previously loaded.
 func instantiate_dialog_box(
 		character_name: String,
 		dialog_box_parent: Node = null,
 		dialog_box_override: DialogBox = null,
-		dialog_box_char_override: DialogBox = null,
+		ignore_display_override: bool = false,
+		dialog_box_char_override: Dictionary = {
+			"dialog_box": null,
+			"ignore_display_override": false
+		},
 	) -> DialogBox:
-	var dialog_box = dialog_box_char_override
+	var dialog_box = dialog_box_char_override["dialog_box"]
+	var using_default_override = false
 	if not dialog_box:
 		# If there is no override for the character, instantiate it from the character data
 		var dialog_box_uid = ""
@@ -287,6 +294,7 @@ func instantiate_dialog_box(
 			if dialog_box_override:
 				# If there is a dialog box default override, use it
 				dialog_box = dialog_box_override
+				using_default_override = true
 			else: # If no override, use the default dialog box from settings
 				dialog_box_uid = SproutyDialogsSettingsManager.get_setting("default_dialog_box")
 
@@ -300,12 +308,22 @@ func instantiate_dialog_box(
 				return null
 			dialog_box = _dialog_boxes[dialog_box_path].instantiate()
 
-	if not dialog_box.get_parent():
-		if dialog_box_parent:
-			# Add the dialog box to the specified parent
+	if dialog_box_parent:
+		# If there is a parent override, and no ignore display override, add it to the parent
+		if using_default_override and not ignore_display_override:
+			if dialog_box.get_parent():
+				dialog_box.get_parent().remove_child(dialog_box)
 			dialog_box_parent.add_child(dialog_box)
-		else: # If not, add the dialog box to the default canvas
-			_dialog_boxes_canvas.add_child(dialog_box)
+		if not using_default_override and not dialog_box_char_override["ignore_display_override"]:
+			if dialog_box.get_parent():
+				dialog_box.get_parent().remove_child(dialog_box)
+			dialog_box_parent.add_child(dialog_box)
+		# If does not have a parent, but there is a parent override, add to it
+		elif not dialog_box.get_parent():
+			dialog_box_parent.add_child(dialog_box)
+	# If there is no parent override, add it to the default canvas 
+	elif not dialog_box.get_parent(): # (If does not have a parent yet)
+		_dialog_boxes_canvas.add_child(dialog_box)
 
 	return dialog_box
 


### PR DESCRIPTION
## New "Dialog Box Overrides" section in DialogPlayer

<img width="305" height="255" alt="image" src="https://github.com/user-attachments/assets/9f3f028e-85a0-444d-b4c8-9cee15397da1" />

Now you can override the dialog boxes for the entire dialog or each character on the inspector:
- You can assign a **default dialog box override for the entire dialog**, to use a different custom dialog box from the default one configured in the settings. 
- If your **characters have a custom dialog box assigned already**, this dialog box has higher priority, so **is going to be used instead of the default override**. 
- Now, to override the dialog box assigned in a character, **you can assign an override for each specific character**.

The dialog box overrides has the following priority: 
`Character Override > Character Custom > Default Override > Default from settings`

>[!important]
>Both the default dialog box override and each character's dialog box override have a flag that **allows you to ignore the override from their parent or display**.
>
>This means that if you have [display overrides](https://github.com/SproutyLabs/SproutyDialogs/pull/133) configured for different characters but don't want to use them with your dialog box override because it **already has a parent in the scene**, you can choose not to use them by enabling this option.

## New dialog box overrides methods
New methods to handle the dialog box overrides have been added:
  ```gdscript
  func get_dialog_box_override(character_name: String = "") -> DialogBox:

  func set_dialog_box_override(dialog_box: DialogBox, ignore_display_override: bool = false, character_name: String = "") -> void:
  ```
*In each method, the `character_name` parameter is optional, because if no character is given the method return or modify the default dialog box override.*