### PR TITLE
Recover editor state from project settings

### DIFF
--- a/addons/sprouty_dialogs/plugin.gd
+++ b/addons/sprouty_dialogs/plugin.gd
@@ -36,6 +36,10 @@ func _enter_tree():
 			SproutyDialogsSettingsManager.migrate_settings_from_graph_dialogs()
 		else: # Initialize default settings for new users.
 			SproutyDialogsSettingsManager.initialize_default_settings()
+	
+	# Migrate editor state from project settings to the cache file if it exists.
+	if ProjectSettings.has_setting("sprouty_dialogs/internal/last_opened_files"):
+		SproutyDialogsEditorStateManager.migrate_editor_state_from_project_settings()
 
 
 func _exit_tree():

--- a/addons/sprouty_dialogs/utils/editor_state_manager.gd
+++ b/addons/sprouty_dialogs/utils/editor_state_manager.gd
@@ -69,3 +69,22 @@ static func set_value(section: String, key: String, value: Variant) -> void:
 
 	_editor_state_file.set_value(section, key, value)
 	_editor_state_file.save(EDITOR_STATE_FILE_PATH)
+
+
+## Migrates editor state from project settings to the cache file.
+## This function is called when the plugin is first loaded, and it checks if there are any
+## editor state values stored in the project settings. If there are, it migrates them to
+## the cache file and removes them from the project settings.
+static func migrate_editor_state_from_project_settings() -> void:
+	var settings := [
+		"sprouty_dialogs/internal/play_dialog_path",
+		"sprouty_dialogs/internal/play_start_id",
+		"sprouty_dialogs/internal/last_opened_files",
+		"sprouty_dialogs/internal/last_selected_file_index"
+	]
+	for setting in settings:
+		if ProjectSettings.has_setting(setting):
+			var value := ProjectSettings.get_setting(setting)
+			var key = setting.split("/")[-1]
+			set_value("window_state", key, value)
+			ProjectSettings.set_setting(setting, null)


### PR DESCRIPTION
Recover the editor state from the project settings to migrate to the new cache file when the plugin starts.